### PR TITLE
Update dependency install instruction links

### DIFF
--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -17,6 +17,7 @@ import OpenApi
 import OpenApi.Generate
 import OpenApi.Info
 import Pages.Script
+import String.Extra
 import Url
 import UrlPath
 import Yaml.Decode
@@ -198,9 +199,9 @@ generateFileFromOpenApiSpec config apiSpec =
         |> BackendTask.andThen
             (\outputPath ->
                 let
-                    pad4 : String -> String
-                    pad4 =
-                        String.padLeft 4 ' '
+                    indentBy : Int -> String -> String
+                    indentBy amount input =
+                        String.padLeft amount ' ' input
 
                     requiredLinks : List String
                     requiredLinks =
@@ -218,50 +219,22 @@ generateFileFromOpenApiSpec config apiSpec =
                             { text = dependency
                             , url = "https://package.elm-lang.org/packages/" ++ dependency ++ "/latest/"
                             }
-
-                    joinLinks : List String -> String
-                    joinLinks links =
-                        case List.length links of
-                            0 ->
-                                ""
-
-                            1 ->
-                                List.head links
-                                    |> Maybe.withDefault "(unknown)"
-
-                            2 ->
-                                String.join " and " links
-
-                            _ ->
-                                let
-                                    head : String
-                                    head =
-                                        List.take (List.length links - 1) links
-                                            |> String.join ", "
-
-                                    tail : String
-                                    tail =
-                                        List.drop (List.length links - 1) links
-                                            |> List.head
-                                            |> Maybe.withDefault "(unknown)"
-                                in
-                                head ++ ", and " ++ tail
                 in
                 [ ""
                 , "🎉 SDK generated:"
                 , ""
-                , pad4 outputPath
+                , indentBy 4 outputPath
                 , ""
                 , ""
-                , "You'll also need " ++ joinLinks requiredLinks ++ " installed. Try running:"
+                , "You'll also need " ++ String.Extra.toSentenceOxford requiredLinks ++ " installed. Try running:"
                 , ""
-                , pad4 "elm install elm/http"
-                , pad4 "elm install elm/json"
+                , indentBy 4 "elm install elm/http"
+                , indentBy 4 "elm install elm/json"
                 , ""
                 , ""
-                , "and possibly need " ++ joinLinks optionalLinks ++ " installed. If that's the case, try running:"
-                , pad4 "elm install elm/bytes"
-                , pad4 "elm install elm/url"
+                , "and possibly need " ++ String.Extra.toSentenceOxford optionalLinks ++ " installed. If that's the case, try running:"
+                , indentBy 4 "elm install elm/bytes"
+                , indentBy 4 "elm install elm/url"
                 ]
                     |> List.map Pages.Script.log
                     |> doAll

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -201,7 +201,7 @@ generateFileFromOpenApiSpec config apiSpec =
                 let
                     indentBy : Int -> String -> String
                     indentBy amount input =
-                        String.padLeft amount ' ' input
+                        String.repeat amount " " ++ input
 
                     requiredLinks : List String
                     requiredLinks =

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -197,39 +197,71 @@ generateFileFromOpenApiSpec config apiSpec =
             )
         |> BackendTask.andThen
             (\outputPath ->
+                let
+                    pad4 : String -> String
+                    pad4 =
+                        String.padLeft 4 ' '
+
+                    requiredLinks : List String
+                    requiredLinks =
+                        [ "elm/http", "elm/json" ]
+                            |> List.map toElmDependencyLink
+
+                    optionalLinks : List String
+                    optionalLinks =
+                        [ "elm/bytes", "elm/url" ]
+                            |> List.map toElmDependencyLink
+
+                    toElmDependencyLink : String -> String
+                    toElmDependencyLink dependency =
+                        Ansi.link
+                            { text = dependency
+                            , url = "https://package.elm-lang.org/packages/" ++ dependency ++ "/latest/"
+                            }
+
+                    joinLinks : List String -> String
+                    joinLinks links =
+                        case List.length links of
+                            0 ->
+                                ""
+
+                            1 ->
+                                List.head links
+                                    |> Maybe.withDefault "(unknown)"
+
+                            2 ->
+                                String.join " and " links
+
+                            _ ->
+                                let
+                                    head : String
+                                    head =
+                                        List.take (List.length links - 1) links
+                                            |> String.join ", "
+
+                                    tail : String
+                                    tail =
+                                        List.drop (List.length links - 1) links
+                                            |> List.head
+                                            |> Maybe.withDefault "(unknown)"
+                                in
+                                head ++ ", and " ++ tail
+                in
                 [ ""
                 , "🎉 SDK generated:"
                 , ""
-                , "    " ++ outputPath
-
-                -- , outputPaths
-                --     |> List.map (\outputPath -> "    " ++ outputPath)
+                , pad4 outputPath
                 , ""
                 , ""
-                , "You'll also need "
-                    ++ Ansi.link
-                        { text = "elm/http"
-                        , url = "https://package.elm-lang.org/packages/elm/http/latest/"
-                        }
-                    ++ " and "
-                    ++ Ansi.link
-                        { text = "elm/json"
-                        , url = "https://package.elm-lang.org/packages/elm/json/latest/"
-                        }
-                    ++ " installed. Try running:"
+                , "You'll also need " ++ joinLinks requiredLinks ++ " installed. Try running:"
                 , ""
-                , "    elm install elm/http"
-                , "    elm install elm/json"
+                , pad4 "elm install elm/http"
+                , pad4 "elm install elm/json"
                 , ""
                 , ""
-                , "and possibly need "
-                    ++ Ansi.link
-                        { text = "elm/bytes"
-                        , url = "https://package.elm-lang.org/packages/elm/bytes/latest/"
-                        }
-                    ++ " installed. Try running:"
-                , ""
-                , "    elm install elm/bytes"
+                , "and possibly need " ++ joinLinks optionalLinks ++ " installed. If that's the case, try running:"
+                , pad4 "elm install elm/bytes"
+                , pad4 "elm install elm/url"
                 ]
                     |> List.map Pages.Script.log
                     |> doAll


### PR DESCRIPTION
The dependency `elm/url` is not included in the optional installs section. I took the liberty of splitting the message into required and optional links and to write a join function to connect links together as the list grows in future.