### PR TITLE
Split generated code into 2 modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Included `elm/url` in the possible dependencies list. ✨ [James Robb](https://github.com/jamesrweb)
+
+### Changed
+
+- Now generates 2 files: `<namespace>/Api.elm` and `<namespace>/OpenApi.elm`, which resolves [issue #81](https://github.com/wolfadex/elm-open-api-cli/issues/81)
+
 ## [0.3.0] - 2024-04-21
 
 ### Added

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,10 +1,11 @@
-
 # Using the CLI
 
 ### Install the CLI:
+
 - `npm install -D elm-open-api`
 
 ### Run the CLI:
+
 - `npx elm-open-api ./page/to/oas.json`
 
 ### Arguments you can pass:
@@ -14,3 +15,87 @@
 - `[--output-dir <output dir>]`: The directory to output to. Defaults to `generated/`.
 - `[--module-name <module name>]`: The Elm module name. Default to `<OAS info.title>`.
 - `[--generateTodos <generateTodos>]`: Whether to generate TODOs for unimplemented endpoints, or fail when something unexpected is encountered. Defaults to `no`. To generate `Debug.todo ""` instead of failing use one of: `yes`, `y`, `true`.
+
+## Example outputs:
+
+Assume we have an OAS file named `my-cool-company-oas.json` and it has a field `"title": "My Coool Company"` and we run the CLI like so
+
+```sh
+npx elm-open-api ./my-cool-company-oas.json
+```
+
+then we'll output like
+
+```sh
+🎉 SDK generated:
+
+    generated/MyCooolCompany/Api.elm
+    generated/MyCooolCompany/OpenApi.elm
+
+
+You'll also need elm/http and elm/json installed. Try running:
+
+    elm install elm/http
+    elm install elm/json
+
+
+and possibly need elm/bytes and elm/url installed. If that's the case, try running:
+    elm install elm/bytes
+    elm install elm/url
+```
+
+That's nice, but maybe we want to have a less specific module name. We could instead run
+
+```sh
+npx elm-open-api ./my-cool-company-oas.json --module-name="My.Comp"
+```
+
+which would result in
+
+```sh
+🎉 SDK generated:
+
+    generated/My/Comp/Api.elm
+    generated/My/Comp/OpenApi.elm
+
+
+You'll also need elm/http and elm/json installed. Try running:
+
+    elm install elm/http
+    elm install elm/json
+
+
+and possibly need elm/bytes and elm/url installed. If that's the case, try running:
+    elm install elm/bytes
+    elm install elm/url
+```
+
+Notice the new path (and Elm module name) for the `Api.elm` and `OpenApi.elm` files.
+
+Alternatively, maybe we have a different directory naming scheme for our project. We could do
+
+```sh
+npx elm-open-api ./my-cool-company-oas.json --output-dir="src"
+```
+
+which gives us
+
+```sh
+🎉 SDK generated:
+
+    src/MyCooolCompany/Api.elm
+    src/MyCooolCompany/OpenApi.elm
+
+
+You'll also need elm/http and elm/json installed. Try running:
+
+    elm install elm/http
+    elm install elm/json
+
+
+and possibly need elm/bytes and elm/url installed. If that's the case, try running:
+    elm install elm/bytes
+    elm install elm/url
+```
+
+This time only the root directory has changed.

--- a/elm.json
+++ b/elm.json
@@ -9,6 +9,7 @@
         "direct": {
             "dillonkearns/elm-cli-options-parser": "3.2.0",
             "dillonkearns/elm-pages": "10.0.3",
+            "elm/bytes": "1.0.8",
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
@@ -31,7 +32,6 @@
             "dillonkearns/elm-form": "3.0.0",
             "dividat/elm-semver": "2.0.0",
             "elm/browser": "1.0.2",
-            "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",

--- a/example/elm.json
+++ b/example/elm.json
@@ -8,6 +8,7 @@
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.2",
+            "elm/bytes": "1.0.8",
             "elm/core": "1.0.5",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
@@ -15,7 +16,6 @@
             "elm-community/json-extra": "4.3.0"
         },
         "indirect": {
-            "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",

--- a/example/src/ExampleGH.elm
+++ b/example/src/ExampleGH.elm
@@ -1,7 +1,14 @@
 module ExampleGH exposing (main)
 
+-- import BimcloudApi20232AlphaRelease
+
+import AirlineCodeLookupApi
 import Browser
+import Bytes
+import Bytes.Decode
+import GithubV3RestApi
 import Http
+import OpenApi
 import RealworldConduitApi
 
 
@@ -22,7 +29,22 @@ type alias Model =
 init : () -> ( Model, Cmd Msg )
 init () =
     ( {}
-    , RealworldConduitApi.getArticle { toMsg = ApiResponse, params = { slug = "" } }
+    , Cmd.batch
+        [ RealworldConduitApi.getArticle
+            { toMsg = ConduitResponse
+            , params = { slug = "" }
+            }
+        , AirlineCodeLookupApi.getairlines
+            { toMsg = AmadeusResponse
+            , params = { airlineCodes = Nothing }
+            }
+
+        -- , BimcloudApi20232AlphaRelease.blobStoreService10BeginBatchUpload
+        --     { toMsg = BimResponse
+        --     , params = { sessionMinusid = Nothing, description = Nothing }
+        --     }
+        , GithubV3RestApi.metaRoot { toMsg = GithubResponse }
+        ]
     )
 
 
@@ -32,13 +54,24 @@ subscriptions _ =
 
 
 type Msg
-    = ApiResponse (Result (RealworldConduitApi.Error RealworldConduitApi.GetArticle_Error String) RealworldConduitApi.SingleArticleResponse)
+    = ConduitResponse (Result (OpenApi.Error RealworldConduitApi.GetArticle_Error String) RealworldConduitApi.SingleArticleResponse)
+    | AmadeusResponse (Result (OpenApi.Error AirlineCodeLookupApi.Getairlines_Error String) AirlineCodeLookupApi.Airlines)
+      -- | BimResponse (Result (OpenApi.Error BimcloudApi20232AlphaRelease.BlobStoreService10BeginBatchUpload_Error Bytes.Bytes) Bytes.Bytes)
+    | GithubResponse (Result (OpenApi.Error () String) GithubV3RestApi.Root)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        ApiResponse response ->
+        ConduitResponse response ->
+            ( model, Cmd.none )
+
+        AmadeusResponse response ->
+            ( model, Cmd.none )
+
+        -- BimResponse response ->
+        --     ( model, Cmd.none )
+        GithubResponse response ->
             ( model, Cmd.none )
 
 

--- a/review/suppressed/NoUnused.Dependencies.json
+++ b/review/suppressed/NoUnused.Dependencies.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "automatically created by": "elm-review suppress",
+  "learn more": "elm-review suppress --help",
+  "suppressions": [
+    { "count": 1, "filePath": "elm.json" }
+  ]
+}

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -128,11 +128,11 @@ generateFileFromOpenApiSpec :
     -> BackendTask.BackendTask FatalError.FatalError ()
 generateFileFromOpenApiSpec config apiSpec =
     let
-        moduleName : String
+        moduleName : List String
         moduleName =
             case config.outputModuleName of
                 Just modName ->
-                    modName
+                    String.split "." modName
 
                 Nothing ->
                     apiSpec
@@ -140,6 +140,7 @@ generateFileFromOpenApiSpec config apiSpec =
                         |> OpenApi.Info.title
                         |> OpenApi.Generate.sanitizeModuleName
                         |> Maybe.withDefault "Api"
+                        |> List.singleton
 
         generateTodos : Bool
         generateTodos =

--- a/src/CliMonad.elm
+++ b/src/CliMonad.elm
@@ -174,14 +174,14 @@ andThen2 f x y =
 Automatically appends the needed `enum` declarations.
 
 -}
-run : { openApi : OpenApi, generateTodos : Bool } -> CliMonad (List Elm.Declaration) -> Result Message ( List Elm.Declaration, List Message )
-run input (CliMonad x) =
+run : List String -> { openApi : OpenApi, generateTodos : Bool } -> CliMonad (List Elm.Declaration) -> Result Message ( List Elm.Declaration, List Message )
+run namespace input (CliMonad x) =
     x input
         |> Result.andThen
             (\( decls, warnings, oneOfs ) ->
                 let
                     (CliMonad h) =
-                        oneOfDeclarations oneOfs |> withPath "While generating `oneOf`s"
+                        oneOfDeclarations namespace oneOfs |> withPath "While generating `oneOf`s"
                 in
                 h input
                     |> Result.map
@@ -195,22 +195,24 @@ run input (CliMonad x) =
 
 
 oneOfDeclarations :
-    Dict OneOfName OneOfData
+    List String
+    -> Dict OneOfName OneOfData
     -> CliMonad (List Elm.Declaration)
-oneOfDeclarations enums =
+oneOfDeclarations namespace enums =
     combineMap
-        oneOfDeclaration
+        (oneOfDeclaration namespace)
         (FastDict.toList enums)
 
 
 oneOfDeclaration :
-    ( OneOfName, OneOfData )
+    List String
+    -> ( OneOfName, OneOfData )
     -> CliMonad Elm.Declaration
-oneOfDeclaration ( oneOfName, variants ) =
+oneOfDeclaration namespace ( oneOfName, variants ) =
     let
         variantDeclaration : { name : VariantName, type_ : Type } -> CliMonad Elm.Variant
         variantDeclaration { name, type_ } =
-            typeToAnnotation type_
+            typeToAnnotation namespace type_
                 |> map
                     (\variantAnnotation ->
                         let
@@ -260,23 +262,23 @@ errorToWarning (CliMonad f) =
         )
 
 
-objectToAnnotation : { useMaybe : Bool } -> Object -> CliMonad Elm.Annotation.Annotation
-objectToAnnotation config fields =
+objectToAnnotation : List String -> { useMaybe : Bool } -> Object -> CliMonad Elm.Annotation.Annotation
+objectToAnnotation namespace config fields =
     FastDict.toList fields
-        |> combineMap (\( k, v ) -> map (Tuple.pair (Common.toValueName k)) (fieldToAnnotation config v))
+        |> combineMap (\( k, v ) -> map (Tuple.pair (Common.toValueName k)) (fieldToAnnotation namespace config v))
         |> map recordType
 
 
-fieldToAnnotation : { useMaybe : Bool } -> Field -> CliMonad Elm.Annotation.Annotation
-fieldToAnnotation { useMaybe } { type_, required } =
+fieldToAnnotation : List String -> { useMaybe : Bool } -> Field -> CliMonad Elm.Annotation.Annotation
+fieldToAnnotation namespace { useMaybe } { type_, required } =
     let
         annotation : CliMonad Elm.Annotation.Annotation
         annotation =
             if useMaybe then
-                typeToAnnotationMaybe type_
+                typeToAnnotationMaybe namespace type_
 
             else
-                typeToAnnotation type_
+                typeToAnnotation namespace type_
     in
     if required then
         annotation
@@ -292,20 +294,20 @@ recordType fields =
         |> Elm.Annotation.record
 
 
-typeToAnnotation : Type -> CliMonad Elm.Annotation.Annotation
-typeToAnnotation type_ =
+typeToAnnotation : List String -> Type -> CliMonad Elm.Annotation.Annotation
+typeToAnnotation namespace type_ =
     case type_ of
         Nullable t ->
-            typeToAnnotation t
+            typeToAnnotation namespace t
                 |> map
                     (\ann ->
-                        Elm.Annotation.namedWith [ "OpenApi" ]
+                        Elm.Annotation.namedWith (namespace ++ [ "OpenApi" ])
                             "Nullable"
                             [ ann ]
                     )
 
         Object fields ->
-            objectToAnnotation { useMaybe = False } fields
+            objectToAnnotation namespace { useMaybe = False } fields
 
         String ->
             succeed Elm.Annotation.string
@@ -320,7 +322,7 @@ typeToAnnotation type_ =
             succeed Elm.Annotation.bool
 
         List t ->
-            map Elm.Annotation.list (typeToAnnotation t)
+            map Elm.Annotation.list (typeToAnnotation namespace t)
 
         OneOf oneOfName oneOfData ->
             oneOfAnnotation oneOfName oneOfData
@@ -338,14 +340,14 @@ typeToAnnotation type_ =
             succeed Elm.Annotation.unit
 
 
-typeToAnnotationMaybe : Type -> CliMonad Elm.Annotation.Annotation
-typeToAnnotationMaybe type_ =
+typeToAnnotationMaybe : List String -> Type -> CliMonad Elm.Annotation.Annotation
+typeToAnnotationMaybe namespace type_ =
     case type_ of
         Nullable t ->
-            map Elm.Annotation.maybe (typeToAnnotationMaybe t)
+            map Elm.Annotation.maybe (typeToAnnotationMaybe namespace t)
 
         Object fields ->
-            objectToAnnotation { useMaybe = True } fields
+            objectToAnnotation namespace { useMaybe = True } fields
 
         String ->
             succeed Elm.Annotation.string
@@ -360,7 +362,7 @@ typeToAnnotationMaybe type_ =
             succeed Elm.Annotation.bool
 
         List t ->
-            map Elm.Annotation.list (typeToAnnotationMaybe t)
+            map Elm.Annotation.list (typeToAnnotationMaybe namespace t)
 
         OneOf oneOfName oneOfData ->
             oneOfAnnotation oneOfName oneOfData

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -193,6 +193,7 @@ formatModuleDocs =
 
                                     memberLine :: restOfLines ->
                                         let
+                                            groupSize : Int
                                             groupSize =
                                                 String.length (String.join ", " memberLine)
                                         in

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -38,20 +38,20 @@ getAlias refUri =
             CliMonad.fail <| "Couldn't get the type ref (" ++ String.join "/" refUri ++ ") for the response"
 
 
-schemaToProperties : Json.Schema.Definitions.Schema -> CliMonad (Dict String Field)
-schemaToProperties allOfItem =
+schemaToProperties : List String -> Json.Schema.Definitions.Schema -> CliMonad (Dict String Field)
+schemaToProperties namespace allOfItem =
     case allOfItem of
         Json.Schema.Definitions.ObjectSchema allOfItemSchema ->
             CliMonad.map2 FastDict.union
-                (subSchemaToProperties allOfItemSchema)
-                (subSchemaRefToProperties allOfItemSchema)
+                (subSchemaToProperties namespace allOfItemSchema)
+                (subSchemaRefToProperties namespace allOfItemSchema)
 
         Json.Schema.Definitions.BooleanSchema _ ->
             CliMonad.todoWithDefault FastDict.empty "Boolean schema inside allOf"
 
 
-subSchemaRefToProperties : Json.Schema.Definitions.SubSchema -> CliMonad (Dict String Field)
-subSchemaRefToProperties allOfItem =
+subSchemaRefToProperties : List String -> Json.Schema.Definitions.SubSchema -> CliMonad (Dict String Field)
+subSchemaRefToProperties namespace allOfItem =
     case allOfItem.ref of
         Nothing ->
             CliMonad.succeed FastDict.empty
@@ -59,11 +59,11 @@ subSchemaRefToProperties allOfItem =
         Just ref ->
             getAlias (String.split "/" ref)
                 |> CliMonad.withPath ref
-                |> CliMonad.andThen schemaToProperties
+                |> CliMonad.andThen (schemaToProperties namespace)
 
 
-subSchemaToProperties : Json.Schema.Definitions.SubSchema -> CliMonad (Dict String Field)
-subSchemaToProperties sch =
+subSchemaToProperties : List String -> Json.Schema.Definitions.SubSchema -> CliMonad (Dict String Field)
+subSchemaToProperties namespace sch =
     -- TODO: rename
     let
         requiredSet : Set String
@@ -77,7 +77,7 @@ subSchemaToProperties sch =
         |> Maybe.withDefault []
         |> CliMonad.combineMap
             (\( key, valueSchema ) ->
-                schemaToType valueSchema
+                schemaToType namespace valueSchema
                     |> CliMonad.withPath key
                     |> CliMonad.map
                         (\type_ ->
@@ -91,8 +91,8 @@ subSchemaToProperties sch =
         |> CliMonad.map FastDict.fromList
 
 
-schemaToType : Json.Schema.Definitions.Schema -> CliMonad Type
-schemaToType schema =
+schemaToType : List String -> Json.Schema.Definitions.Schema -> CliMonad Type
+schemaToType namespace schema =
     case schema of
         Json.Schema.Definitions.BooleanSchema _ ->
             CliMonad.todoWithDefault Value "Boolean schema"
@@ -107,7 +107,7 @@ schemaToType schema =
                 singleTypeToType singleType =
                     case singleType of
                         Json.Schema.Definitions.ObjectType ->
-                            objectSchemaToType subSchema
+                            objectSchemaToType namespace subSchema
 
                         Json.Schema.Definitions.StringType ->
                             CliMonad.succeed String
@@ -133,7 +133,7 @@ schemaToType schema =
                                     CliMonad.todoWithDefault Value "Array of items as item definition"
 
                                 Json.Schema.Definitions.ItemDefinition itemSchema ->
-                                    CliMonad.map List (schemaToType itemSchema)
+                                    CliMonad.map List (schemaToType namespace itemSchema)
 
                 anyOfToType : List Json.Schema.Definitions.Schema -> CliMonad Type
                 anyOfToType _ =
@@ -141,8 +141,8 @@ schemaToType schema =
 
                 oneOfToType : List Json.Schema.Definitions.Schema -> CliMonad Type
                 oneOfToType oneOf =
-                    CliMonad.combineMap schemaToType oneOf
-                        |> CliMonad.andThen oneOfType
+                    CliMonad.combineMap (schemaToType namespace) oneOf
+                        |> CliMonad.andThen (oneOfType namespace)
             in
             case subSchema.type_ of
                 Json.Schema.Definitions.SingleType singleType ->
@@ -156,7 +156,7 @@ schemaToType schema =
                         Nothing ->
                             case subSchema.anyOf of
                                 Just [ onlySchema ] ->
-                                    schemaToType onlySchema
+                                    schemaToType namespace onlySchema
 
                                 Just [ firstSchema, secondSchema ] ->
                                     case ( firstSchema, secondSchema ) of
@@ -166,10 +166,10 @@ schemaToType schema =
                                             -- mark a value as nullable in the schema.
                                             case ( firstSubSchema.type_, secondSubSchema.type_ ) of
                                                 ( Json.Schema.Definitions.SingleType Json.Schema.Definitions.NullType, _ ) ->
-                                                    nullable (schemaToType secondSchema)
+                                                    nullable (schemaToType namespace secondSchema)
 
                                                 ( _, Json.Schema.Definitions.SingleType Json.Schema.Definitions.NullType ) ->
-                                                    nullable (schemaToType firstSchema)
+                                                    nullable (schemaToType namespace firstSchema)
 
                                                 _ ->
                                                     anyOfToType [ firstSchema, secondSchema ]
@@ -183,7 +183,7 @@ schemaToType schema =
                                 Nothing ->
                                     case subSchema.allOf of
                                         Just [ onlySchema ] ->
-                                            schemaToType onlySchema
+                                            schemaToType namespace onlySchema
 
                                         Just [] ->
                                             CliMonad.succeed Value
@@ -191,12 +191,12 @@ schemaToType schema =
                                         Just _ ->
                                             -- If we have more than one item in `allOf`, then it's _probably_ an object
                                             -- TODO: improve this to actually check if all the `allOf` subschema are objects.
-                                            objectSchemaToType subSchema
+                                            objectSchemaToType namespace subSchema
 
                                         Nothing ->
                                             case subSchema.oneOf of
                                                 Just [ onlySchema ] ->
-                                                    schemaToType onlySchema
+                                                    schemaToType namespace onlySchema
 
                                                 Just [] ->
                                                     CliMonad.succeed Value
@@ -219,7 +219,7 @@ schemaToType schema =
                     in
                     nonNulls
                         |> CliMonad.combineMap singleTypeToType
-                        |> CliMonad.andThen oneOfType
+                        |> CliMonad.andThen (oneOfType namespace)
                         |> CliMonad.map
                             (\res ->
                                 if List.isEmpty nulls then
@@ -230,10 +230,10 @@ schemaToType schema =
                             )
 
 
-typeToOneOfVariant : Type -> CliMonad (Maybe { name : TypeName, type_ : Type })
-typeToOneOfVariant type_ =
+typeToOneOfVariant : List String -> Type -> CliMonad (Maybe { name : TypeName, type_ : Type })
+typeToOneOfVariant namespace type_ =
     type_
-        |> CliMonad.typeToAnnotation
+        |> CliMonad.typeToAnnotation namespace
         |> CliMonad.map
             (\ann ->
                 let
@@ -255,10 +255,10 @@ typeToOneOfVariant type_ =
             )
 
 
-oneOfType : List Type -> CliMonad Type
-oneOfType types =
+oneOfType : List String -> List Type -> CliMonad Type
+oneOfType namespace types =
     types
-        |> CliMonad.combineMap typeToOneOfVariant
+        |> CliMonad.combineMap (typeToOneOfVariant namespace)
         |> CliMonad.map
             (\maybeVariants ->
                 case Maybe.Extra.combine maybeVariants of
@@ -284,14 +284,14 @@ oneOfType types =
             )
 
 
-objectSchemaToType : Json.Schema.Definitions.SubSchema -> CliMonad Type
-objectSchemaToType subSchema =
+objectSchemaToType : List String -> Json.Schema.Definitions.SubSchema -> CliMonad Type
+objectSchemaToType namespace subSchema =
     let
         propertiesFromAllOf : CliMonad (Dict String Field)
         propertiesFromAllOf =
             subSchema.allOf
                 |> Maybe.withDefault []
-                |> CliMonad.combineMap schemaToProperties
+                |> CliMonad.combineMap (schemaToProperties namespace)
                 |> CliMonad.map (List.foldl FastDict.union FastDict.empty)
     in
     CliMonad.map2
@@ -300,10 +300,10 @@ objectSchemaToType subSchema =
                 |> FastDict.union schemaProps
                 |> Object
         )
-        (subSchemaToProperties subSchema)
+        (subSchemaToProperties namespace subSchema)
         propertiesFromAllOf
 
 
-schemaToAnnotation : Json.Schema.Definitions.Schema -> CliMonad Elm.Annotation.Annotation
-schemaToAnnotation schema =
-    schemaToType schema |> CliMonad.andThen CliMonad.typeToAnnotation
+schemaToAnnotation : List String -> Json.Schema.Definitions.Schema -> CliMonad Elm.Annotation.Annotation
+schemaToAnnotation namespace schema =
+    schemaToType namespace schema |> CliMonad.andThen (CliMonad.typeToAnnotation namespace)

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -1,4 +1,8 @@
-module SchemaUtils exposing (getAlias, schemaToAnnotation, schemaToType)
+module SchemaUtils exposing
+    ( getAlias
+    , schemaToAnnotation
+    , schemaToType
+    )
 
 import CliMonad exposing (CliMonad)
 import Common exposing (Field, Type(..), TypeName, typifyName)
@@ -271,7 +275,12 @@ oneOfType types =
                             names =
                                 List.map .name sortedVariants
                         in
-                        OneOf (String.join "Or" names) sortedVariants
+                        OneOf
+                            (names
+                                |> List.map CliMonad.fixOneOfName
+                                |> String.join "_Or_"
+                            )
+                            sortedVariants
             )
 
 


### PR DESCRIPTION
The generated code is now split into 2 files/modules:
- `<directory>/<namespace>/OpenApi.elm`
- `<directory>/<namespace>/Api.elm`

The `OpenApi` module is responsible for things like the custom error type, the vendored json `andMap`, and other helper functions and types.

The `Api` module is what matches the schema and provides the http requests and json decoders/encoders/