### PR TITLE
Rename the Error type

### DIFF
--- a/example/src/Example.elm
+++ b/example/src/Example.elm
@@ -7,6 +7,7 @@ import AirlineCodeLookupApi.Types
 import Browser
 import GithubV3RestApi.Api
 import GithubV3RestApi.Types
+import OpenApi.Common
 import RealworldConduitApi.Api
 import RealworldConduitApi.Types
 
@@ -53,10 +54,10 @@ subscriptions _ =
 
 
 type Msg
-    = ConduitResponse (Result (RealworldConduitApi.Types.OAError RealworldConduitApi.Types.GetArticle_Error String) RealworldConduitApi.Types.SingleArticleResponse)
-    | AmadeusResponse (Result (AirlineCodeLookupApi.Types.OAError AirlineCodeLookupApi.Types.Getairlines_Error String) AirlineCodeLookupApi.Types.Airlines)
-      -- | BimResponse (Result (RealworldConduitApi.Types.OAError BimcloudApi20232AlphaRelease.BlobStoreService10BeginBatchUpload_Error Bytes.Bytes) Bytes.Bytes)
-    | GithubResponse (Result (GithubV3RestApi.Types.OAError () String) GithubV3RestApi.Types.Root)
+    = ConduitResponse (Result (OpenApi.Common.Error RealworldConduitApi.Types.GetArticle_Error String) RealworldConduitApi.Types.SingleArticleResponse)
+    | AmadeusResponse (Result (OpenApi.Common.Error AirlineCodeLookupApi.Types.Getairlines_Error String) AirlineCodeLookupApi.Types.Airlines)
+      -- | BimResponse (Result (OpenApi.Common.Error BimcloudApi20232AlphaRelease.BlobStoreService10BeginBatchUpload_Error Bytes.Bytes) Bytes.Bytes)
+    | GithubResponse (Result (OpenApi.Common.Error () String) GithubV3RestApi.Types.Root)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/example/src/Example.elm
+++ b/example/src/Example.elm
@@ -53,10 +53,10 @@ subscriptions _ =
 
 
 type Msg
-    = ConduitResponse (Result (RealworldConduitApi.Types.Error RealworldConduitApi.Types.GetArticle_Error String) RealworldConduitApi.Types.SingleArticleResponse)
-    | AmadeusResponse (Result (AirlineCodeLookupApi.Types.Error AirlineCodeLookupApi.Types.Getairlines_Error String) AirlineCodeLookupApi.Types.Airlines)
-      -- | BimResponse (Result (RealworldConduitApi.Types.Error BimcloudApi20232AlphaRelease.BlobStoreService10BeginBatchUpload_Error Bytes.Bytes) Bytes.Bytes)
-    | GithubResponse (Result (GithubV3RestApi.Types.Error () String) GithubV3RestApi.Types.Root)
+    = ConduitResponse (Result (RealworldConduitApi.Types.OAError RealworldConduitApi.Types.GetArticle_Error String) RealworldConduitApi.Types.SingleArticleResponse)
+    | AmadeusResponse (Result (AirlineCodeLookupApi.Types.OAError AirlineCodeLookupApi.Types.Getairlines_Error String) AirlineCodeLookupApi.Types.Airlines)
+      -- | BimResponse (Result (RealworldConduitApi.Types.OAError BimcloudApi20232AlphaRelease.BlobStoreService10BeginBatchUpload_Error Bytes.Bytes) Bytes.Bytes)
+    | GithubResponse (Result (GithubV3RestApi.Types.OAError () String) GithubV3RestApi.Types.Root)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -7,7 +7,7 @@ module Common exposing
     , Type(..)
     , TypeName
     , VariantName
-    , moduleToString
+    , moduleToNamespace
     , ref
     , toValueName
     , typifyName
@@ -21,6 +21,11 @@ type Module
     = Json
     | Types
     | Api
+
+
+moduleToNamespace : List String -> Module -> List String
+moduleToNamespace namespace module_ =
+    namespace ++ [ moduleToString module_ ]
 
 
 moduleToString : Module -> String

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -21,24 +21,23 @@ type Module
     = Json
     | Types
     | Api
+    | Common
 
 
 moduleToNamespace : List String -> Module -> List String
 moduleToNamespace namespace module_ =
-    namespace ++ [ moduleToString module_ ]
-
-
-moduleToString : Module -> String
-moduleToString module_ =
     case module_ of
         Json ->
-            "Json"
+            namespace ++ [ "Json" ]
 
         Types ->
-            "Types"
+            namespace ++ [ "Types" ]
 
         Api ->
-            "Api"
+            namespace ++ [ "Api" ]
+
+        Common ->
+            [ "OpenApi", "Common" ]
 
 
 

--- a/src/JsonSchema/Generate.elm
+++ b/src/JsonSchema/Generate.elm
@@ -39,7 +39,7 @@ schemaToDeclarations namespace name schema =
                             , Elm.declaration
                                 ("decode" ++ typeName)
                                 (schemaDecoder
-                                    |> Elm.withType (Gen.Json.Decode.annotation_.decoder (Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ]) typeName))
+                                    |> Elm.withType (Gen.Json.Decode.annotation_.decoder (Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) typeName))
                                 )
                                 |> Elm.exposeWith
                                     { exposeConstructor = False
@@ -53,7 +53,7 @@ schemaToDeclarations namespace name schema =
                             ( Common.Json
                             , Elm.declaration ("encode" ++ typeName)
                                 (Elm.functionReduced "rec" encoder
-                                    |> Elm.withType (Elm.Annotation.function [ Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ]) typeName ] Gen.Json.Encode.annotation_.value)
+                                    |> Elm.withType (Elm.Annotation.function [ Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) typeName ] Gen.Json.Encode.annotation_.value)
                                 )
                                 |> Elm.exposeWith
                                     { exposeConstructor = False

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -156,7 +156,7 @@ files { namespace, generateTodos, effectTypes, server } apiSpec =
                     |> List.Extra.gatherEqualsBy Tuple.first
                     |> List.map
                         (\( ( module_, head ), tail ) ->
-                            Elm.fileWith (namespace ++ [ Common.moduleToString module_ ])
+                            Elm.fileWith (Common.moduleToNamespace namespace module_)
                                 { docs =
                                     \docs ->
                                         docs
@@ -327,7 +327,7 @@ unitDeclarations namespace name =
                 ( Common.Json
                 , Elm.declaration ("decode" ++ typeName)
                     (schemaDecoder
-                        |> Elm.withType (Gen.Json.Decode.annotation_.decoder (Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ]) typeName))
+                        |> Elm.withType (Gen.Json.Decode.annotation_.decoder (Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) typeName))
                     )
                     |> Elm.exposeWith
                         { exposeConstructor = False
@@ -341,7 +341,7 @@ unitDeclarations namespace name =
                 ( Common.Json
                 , Elm.declaration ("encode" ++ typeName)
                     (Elm.functionReduced "rec" encoder
-                        |> Elm.withType (Elm.Annotation.function [ Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ]) typeName ] Gen.Json.Encode.annotation_.value)
+                        |> Elm.withType (Elm.Annotation.function [ Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) typeName ] Gen.Json.Encode.annotation_.value)
                     )
                     |> Elm.exposeWith
                         { exposeConstructor = False
@@ -830,7 +830,7 @@ replacedUrl server namespace pathUrl operation =
 
 customErrorAnnotation : List String -> Elm.Annotation.Annotation -> Elm.Annotation.Annotation -> Elm.Annotation.Annotation
 customErrorAnnotation namespace errorTypeAnnotation bodyTypeAnnotation =
-    Elm.Annotation.namedWith (namespace ++ [ Common.moduleToString Common.Types ])
+    Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types)
         "OAError"
         [ errorTypeAnnotation
         , bodyTypeAnnotation
@@ -1446,7 +1446,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
 
         expectJsonBetter : Elm.Expression -> Elm.Expression -> Elm.Expression -> { core : Elm.Expression, elmPages : Elm.Expression }
         expectJsonBetter errorDecoders successDecoder toMsg =
-            { core = (expectJsonCustom namespace).callFrom (namespace ++ [ Common.moduleToString Common.Json ]) toMsg errorDecoders successDecoder
+            { core = (expectJsonCustom namespace).callFrom (Common.moduleToNamespace namespace Common.Json) toMsg errorDecoders successDecoder
             , elmPages = Gen.BackendTask.Http.expectJson successDecoder
             }
     in
@@ -1484,7 +1484,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                 SchemaUtils.typeToDecoder True namespace type_
                                                                     |> CliMonad.map
                                                                         (Elm.value
-                                                                            { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                            { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                             , name = toErrorVariant statusCode
                                                                             , annotation = Nothing
                                                                             }
@@ -1495,7 +1495,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                 CliMonad.succeed Gen.Json.Decode.string
                                                                     |> CliMonad.map
                                                                         (Elm.value
-                                                                            { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                            { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                             , name = toErrorVariant statusCode
                                                                             , annotation = Nothing
                                                                             }
@@ -1506,7 +1506,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                 CliMonad.succeed (Gen.Debug.todo "decode bytes err?")
                                                                     |> CliMonad.map
                                                                         (Elm.value
-                                                                            { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                            { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                             , name = toErrorVariant statusCode
                                                                             , annotation = Nothing
                                                                             }
@@ -1517,7 +1517,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                 CliMonad.succeed (Gen.Json.Decode.succeed Elm.unit)
                                                                     |> CliMonad.map
                                                                         (Elm.value
-                                                                            { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                            { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                             , name = toErrorVariant statusCode
                                                                             , annotation = Nothing
                                                                             }
@@ -1540,14 +1540,14 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                             |> CliMonad.map
                                                                 (\typeName ->
                                                                     Elm.value
-                                                                        { importFrom = namespace ++ [ Common.moduleToString Common.Json ]
+                                                                        { importFrom = Common.moduleToNamespace namespace Common.Json
                                                                         , name = "decode" ++ typeName
                                                                         , annotation = Nothing
                                                                         }
                                                                 )
                                                             |> CliMonad.map
                                                                 (Elm.value
-                                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                     , name = toErrorVariant statusCode
                                                                     , annotation = Nothing
                                                                     }
@@ -1631,7 +1631,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                 { exposeConstructor = True
                                                 , group = Nothing
                                                 }
-                                    , Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ]) errorName
+                                    , Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) errorName
                                     )
                                 )
                 in
@@ -1650,7 +1650,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                     , errorTypeDeclaration = errorTypeDeclaration_
                                                     , errorTypeAnnotation = errorTypeAnnotation
                                                     , toExpect = expectJsonBetter errorDecoders_ successDecoder
-                                                    , resolver = (jsonResolverCustom namespace).callFrom (namespace ++ [ Common.moduleToString Common.Json ]) errorDecoders_ successDecoder
+                                                    , resolver = (jsonResolverCustom namespace).callFrom (Common.moduleToNamespace namespace Common.Json) errorDecoders_ successDecoder
                                                     }
                                                 )
                                                 (SchemaUtils.typeToDecoder True namespace type_)
@@ -1678,7 +1678,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                             Gen.Result.make_.err
                                                                                 (Elm.apply
                                                                                     (Elm.value
-                                                                                        { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                        { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                         , name = "BadUrl"
                                                                                         , annotation = Nothing
                                                                                         }
@@ -1690,7 +1690,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "Timeout_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                 , name = "Timeout"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1700,7 +1700,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "NetworkError_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                 , name = "NetworkError"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1716,7 +1716,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                     Gen.Result.make_.err
                                                                                         (Elm.apply
                                                                                             (Elm.value
-                                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                                 , name = "UnknownBadStatus"
                                                                                                 , annotation = Nothing
                                                                                                 }
@@ -1732,7 +1732,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                                                 , name = "KnownBadStatus"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1744,7 +1744,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                                                 , name = "BadErrorBody"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1765,7 +1765,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                         Gen.Result.make_.err
                                                                                             (Elm.apply
                                                                                                 (Elm.value
-                                                                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                                     , name = "BadBody"
                                                                                                     , annotation = Nothing
                                                                                                     }
@@ -1807,7 +1807,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                             Gen.Result.make_.err
                                                                                 (Elm.apply
                                                                                     (Elm.value
-                                                                                        { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                        { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                         , name = "BadUrl"
                                                                                         , annotation = Nothing
                                                                                         }
@@ -1819,7 +1819,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "Timeout_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                 , name = "Timeout"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1829,7 +1829,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "NetworkError_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                 , name = "NetworkError"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1845,7 +1845,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                     Gen.Result.make_.err
                                                                                         (Elm.apply
                                                                                             (Elm.value
-                                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                                 , name = "UnknownBadStatus"
                                                                                                 , annotation = Nothing
                                                                                                 }
@@ -1861,7 +1861,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                                                 , name = "KnownBadStatus"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1873,7 +1873,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                                                                 , name = "BadErrorBody"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1904,7 +1904,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                     , errorTypeDeclaration = errorTypeDeclaration_
                                                     , errorTypeAnnotation = errorTypeAnnotation
                                                     , toExpect = expectJsonBetter errorDecoders_ (Gen.Json.Decode.succeed Elm.unit)
-                                                    , resolver = (jsonResolverCustom namespace).callFrom (namespace ++ [ Common.moduleToString Common.Json ]) errorDecoders_ (Gen.Json.Decode.succeed Elm.unit)
+                                                    , resolver = (jsonResolverCustom namespace).callFrom (Common.moduleToNamespace namespace Common.Json) errorDecoders_ (Gen.Json.Decode.succeed Elm.unit)
                                                     }
                                                 )
                                                 errorDecoders
@@ -1932,18 +1932,18 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                 , toExpect =
                                                     expectJsonBetter errorDecoders_
                                                         (Elm.value
-                                                            { importFrom = namespace ++ [ Common.moduleToString Common.Json ]
+                                                            { importFrom = Common.moduleToNamespace namespace Common.Json
                                                             , name = "decode" ++ typeName
                                                             , annotation = Nothing
                                                             }
                                                         )
                                                 , resolver =
                                                     (jsonResolverCustom namespace).callFrom
-                                                        (namespace ++ [ Common.moduleToString Common.Json ])
+                                                        (Common.moduleToNamespace namespace Common.Json)
                                                         errorDecoders_
                                                     <|
                                                         Elm.value
-                                                            { importFrom = namespace ++ [ Common.moduleToString Common.Json ]
+                                                            { importFrom = Common.moduleToNamespace namespace Common.Json
                                                             , name = "decode" ++ typeName
                                                             , annotation = Nothing
                                                             }
@@ -1982,7 +1982,7 @@ expectJsonCustom namespace =
         , Just
             (Elm.Annotation.function
                 [ Gen.Result.annotation_.result
-                    (Elm.Annotation.namedWith (namespace ++ [ Common.moduleToString Common.Types ]) "OAError" [ Elm.Annotation.var "err", Elm.Annotation.string ])
+                    (Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types) "OAError" [ Elm.Annotation.var "err", Elm.Annotation.string ])
                     (Elm.Annotation.var "success")
                 ]
                 (Elm.Annotation.var "msg")
@@ -2008,7 +2008,7 @@ expectJsonCustom namespace =
                                 Gen.Result.make_.err
                                     (Elm.apply
                                         (Elm.value
-                                            { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                            { importFrom = Common.moduleToNamespace namespace Common.Types
                                             , name = "BadUrl"
                                             , annotation = Nothing
                                             }
@@ -2018,7 +2018,7 @@ expectJsonCustom namespace =
                         , timeout_ =
                             Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                     , name = "Timeout"
                                     , annotation = Nothing
                                     }
@@ -2026,7 +2026,7 @@ expectJsonCustom namespace =
                         , networkError_ =
                             Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                     , name = "NetworkError"
                                     , annotation = Nothing
                                     }
@@ -2039,7 +2039,7 @@ expectJsonCustom namespace =
                                         Gen.Result.make_.err
                                             (Elm.apply
                                                 (Elm.value
-                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                     , name = "UnknownBadStatus"
                                                     , annotation = Nothing
                                                     }
@@ -2055,7 +2055,7 @@ expectJsonCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                     , name = "KnownBadStatus"
                                                                     , annotation = Nothing
                                                                     }
@@ -2067,7 +2067,7 @@ expectJsonCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                     , name = "BadErrorBody"
                                                                     , annotation = Nothing
                                                                     }
@@ -2085,7 +2085,7 @@ expectJsonCustom namespace =
                                             Gen.Result.make_.err
                                                 (Elm.apply
                                                     (Elm.value
-                                                        { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                        { importFrom = Common.moduleToNamespace namespace Common.Types
                                                         , name = "BadBody"
                                                         , annotation = Nothing
                                                         }
@@ -2131,7 +2131,7 @@ jsonResolverCustom namespace =
                                 Gen.Result.make_.err
                                     (Elm.apply
                                         (Elm.value
-                                            { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                            { importFrom = Common.moduleToNamespace namespace Common.Types
                                             , name = "BadUrl"
                                             , annotation = Nothing
                                             }
@@ -2142,7 +2142,7 @@ jsonResolverCustom namespace =
                         , Elm.Case.branch0 "Timeout_"
                             (Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                     , name = "Timeout"
                                     , annotation = Nothing
                                     }
@@ -2151,7 +2151,7 @@ jsonResolverCustom namespace =
                         , Elm.Case.branch0 "NetworkError_"
                             (Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                     , name = "NetworkError"
                                     , annotation = Nothing
                                     }
@@ -2167,7 +2167,7 @@ jsonResolverCustom namespace =
                                         Gen.Result.make_.err
                                             (Elm.apply
                                                 (Elm.value
-                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                     , name = "UnknownBadStatus"
                                                     , annotation = Nothing
                                                     }
@@ -2183,7 +2183,7 @@ jsonResolverCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                     , name = "KnownBadStatus"
                                                                     , annotation = Nothing
                                                                     }
@@ -2195,7 +2195,7 @@ jsonResolverCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
                                                                     , name = "BadErrorBody"
                                                                     , annotation = Nothing
                                                                     }
@@ -2215,7 +2215,7 @@ jsonResolverCustom namespace =
                                         \_ ->
                                             Gen.Result.make_.err
                                                 (Elm.apply
-                                                    (Elm.value { importFrom = namespace ++ [ Common.moduleToString Common.Types ], name = "BadBody", annotation = Nothing })
+                                                    (Elm.value { importFrom = Common.moduleToNamespace namespace Common.Types, name = "BadBody", annotation = Nothing })
                                                     [ metadata, body ]
                                                 )
                                     , ok = \a -> Gen.Result.make_.ok a

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -831,7 +831,7 @@ replacedUrl server namespace pathUrl operation =
 customErrorAnnotation : List String -> Elm.Annotation.Annotation -> Elm.Annotation.Annotation -> Elm.Annotation.Annotation
 customErrorAnnotation namespace errorTypeAnnotation bodyTypeAnnotation =
     Elm.Annotation.namedWith (namespace ++ [ Common.moduleToString Common.Types ])
-        "Error"
+        "OAError"
         [ errorTypeAnnotation
         , bodyTypeAnnotation
         ]
@@ -1957,7 +1957,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
 
 customHttpError : Elm.Declaration
 customHttpError =
-    Elm.customType "Error"
+    Elm.customType "OAError"
         [ Elm.variantWith "BadUrl" [ Elm.Annotation.string ]
         , Elm.variant "Timeout"
         , Elm.variant "NetworkError"
@@ -1982,7 +1982,7 @@ expectJsonCustom namespace =
         , Just
             (Elm.Annotation.function
                 [ Gen.Result.annotation_.result
-                    (Elm.Annotation.namedWith (namespace ++ [ Common.moduleToString Common.Types ]) "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ])
+                    (Elm.Annotation.namedWith (namespace ++ [ Common.moduleToString Common.Types ]) "OAError" [ Elm.Annotation.var "err", Elm.Annotation.string ])
                     (Elm.Annotation.var "success")
                 ]
                 (Elm.Annotation.var "msg")

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -136,18 +136,18 @@ files { namespace, generateTodos, effectTypes, server } apiSpec =
                                         , group = Just "Decoders"
                                         }
                                  )
-                               , ( Common.Types
+                               , ( Common.Common
                                  , customHttpError
                                     |> Elm.exposeWith
                                         { exposeConstructor = True
-                                        , group = Just "Open API"
+                                        , group = Nothing
                                         }
                                  )
-                               , ( Common.Types
+                               , ( Common.Common
                                  , nullableType
                                     |> Elm.exposeWith
                                         { exposeConstructor = True
-                                        , group = Just "Open API"
+                                        , group = Nothing
                                         }
                                  )
                                ]
@@ -830,8 +830,8 @@ replacedUrl server namespace pathUrl operation =
 
 customErrorAnnotation : List String -> Elm.Annotation.Annotation -> Elm.Annotation.Annotation -> Elm.Annotation.Annotation
 customErrorAnnotation namespace errorTypeAnnotation bodyTypeAnnotation =
-    Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types)
-        "OAError"
+    Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Common)
+        "Error"
         [ errorTypeAnnotation
         , bodyTypeAnnotation
         ]
@@ -1678,7 +1678,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                             Gen.Result.make_.err
                                                                                 (Elm.apply
                                                                                     (Elm.value
-                                                                                        { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                        { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                         , name = "BadUrl"
                                                                                         , annotation = Nothing
                                                                                         }
@@ -1690,7 +1690,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "Timeout_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                 , name = "Timeout"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1700,7 +1700,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "NetworkError_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                 , name = "NetworkError"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1716,7 +1716,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                     Gen.Result.make_.err
                                                                                         (Elm.apply
                                                                                             (Elm.value
-                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                                 , name = "UnknownBadStatus"
                                                                                                 , annotation = Nothing
                                                                                                 }
@@ -1732,7 +1732,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                                                 , name = "KnownBadStatus"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1744,7 +1744,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                                                 , name = "BadErrorBody"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1765,7 +1765,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                         Gen.Result.make_.err
                                                                                             (Elm.apply
                                                                                                 (Elm.value
-                                                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                                     , name = "BadBody"
                                                                                                     , annotation = Nothing
                                                                                                     }
@@ -1807,7 +1807,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                             Gen.Result.make_.err
                                                                                 (Elm.apply
                                                                                     (Elm.value
-                                                                                        { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                        { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                         , name = "BadUrl"
                                                                                         , annotation = Nothing
                                                                                         }
@@ -1819,7 +1819,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "Timeout_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                 , name = "Timeout"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1829,7 +1829,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                         "NetworkError_"
                                                                         (Gen.Result.make_.err
                                                                             (Elm.value
-                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                 , name = "NetworkError"
                                                                                 , annotation = Nothing
                                                                                 }
@@ -1845,7 +1845,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                     Gen.Result.make_.err
                                                                                         (Elm.apply
                                                                                             (Elm.value
-                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                                 , name = "UnknownBadStatus"
                                                                                                 , annotation = Nothing
                                                                                                 }
@@ -1861,7 +1861,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                                                 , name = "KnownBadStatus"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1873,7 +1873,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                                                                                     Gen.Result.make_.err
                                                                                                         (Elm.apply
                                                                                                             (Elm.value
-                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                                                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                                                                 , name = "BadErrorBody"
                                                                                                                 , annotation = Nothing
                                                                                                                 }
@@ -1957,7 +1957,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
 
 customHttpError : Elm.Declaration
 customHttpError =
-    Elm.customType "OAError"
+    Elm.customType "Error"
         [ Elm.variantWith "BadUrl" [ Elm.Annotation.string ]
         , Elm.variant "Timeout"
         , Elm.variant "NetworkError"
@@ -1982,7 +1982,7 @@ expectJsonCustom namespace =
         , Just
             (Elm.Annotation.function
                 [ Gen.Result.annotation_.result
-                    (Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types) "OAError" [ Elm.Annotation.var "err", Elm.Annotation.string ])
+                    (Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Common) "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ])
                     (Elm.Annotation.var "success")
                 ]
                 (Elm.Annotation.var "msg")
@@ -2008,7 +2008,7 @@ expectJsonCustom namespace =
                                 Gen.Result.make_.err
                                     (Elm.apply
                                         (Elm.value
-                                            { importFrom = Common.moduleToNamespace namespace Common.Types
+                                            { importFrom = Common.moduleToNamespace namespace Common.Common
                                             , name = "BadUrl"
                                             , annotation = Nothing
                                             }
@@ -2018,7 +2018,7 @@ expectJsonCustom namespace =
                         , timeout_ =
                             Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                     , name = "Timeout"
                                     , annotation = Nothing
                                     }
@@ -2026,7 +2026,7 @@ expectJsonCustom namespace =
                         , networkError_ =
                             Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                     , name = "NetworkError"
                                     , annotation = Nothing
                                     }
@@ -2039,7 +2039,7 @@ expectJsonCustom namespace =
                                         Gen.Result.make_.err
                                             (Elm.apply
                                                 (Elm.value
-                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                                     , name = "UnknownBadStatus"
                                                     , annotation = Nothing
                                                     }
@@ -2055,7 +2055,7 @@ expectJsonCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                     , name = "KnownBadStatus"
                                                                     , annotation = Nothing
                                                                     }
@@ -2067,7 +2067,7 @@ expectJsonCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                     , name = "BadErrorBody"
                                                                     , annotation = Nothing
                                                                     }
@@ -2085,7 +2085,7 @@ expectJsonCustom namespace =
                                             Gen.Result.make_.err
                                                 (Elm.apply
                                                     (Elm.value
-                                                        { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                        { importFrom = Common.moduleToNamespace namespace Common.Common
                                                         , name = "BadBody"
                                                         , annotation = Nothing
                                                         }
@@ -2131,7 +2131,7 @@ jsonResolverCustom namespace =
                                 Gen.Result.make_.err
                                     (Elm.apply
                                         (Elm.value
-                                            { importFrom = Common.moduleToNamespace namespace Common.Types
+                                            { importFrom = Common.moduleToNamespace namespace Common.Common
                                             , name = "BadUrl"
                                             , annotation = Nothing
                                             }
@@ -2142,7 +2142,7 @@ jsonResolverCustom namespace =
                         , Elm.Case.branch0 "Timeout_"
                             (Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                     , name = "Timeout"
                                     , annotation = Nothing
                                     }
@@ -2151,7 +2151,7 @@ jsonResolverCustom namespace =
                         , Elm.Case.branch0 "NetworkError_"
                             (Gen.Result.make_.err
                                 (Elm.value
-                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                     , name = "NetworkError"
                                     , annotation = Nothing
                                     }
@@ -2167,7 +2167,7 @@ jsonResolverCustom namespace =
                                         Gen.Result.make_.err
                                             (Elm.apply
                                                 (Elm.value
-                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                                     , name = "UnknownBadStatus"
                                                     , annotation = Nothing
                                                     }
@@ -2183,7 +2183,7 @@ jsonResolverCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                     , name = "KnownBadStatus"
                                                                     , annotation = Nothing
                                                                     }
@@ -2195,7 +2195,7 @@ jsonResolverCustom namespace =
                                                         Gen.Result.make_.err
                                                             (Elm.apply
                                                                 (Elm.value
-                                                                    { importFrom = Common.moduleToNamespace namespace Common.Types
+                                                                    { importFrom = Common.moduleToNamespace namespace Common.Common
                                                                     , name = "BadErrorBody"
                                                                     , annotation = Nothing
                                                                     }
@@ -2215,7 +2215,7 @@ jsonResolverCustom namespace =
                                         \_ ->
                                             Gen.Result.make_.err
                                                 (Elm.apply
-                                                    (Elm.value { importFrom = Common.moduleToNamespace namespace Common.Types, name = "BadBody", annotation = Nothing })
+                                                    (Elm.value { importFrom = Common.moduleToNamespace namespace Common.Common, name = "BadBody", annotation = Nothing })
                                                     [ metadata, body ]
                                                 )
                                     , ok = \a -> Gen.Result.make_.ok a

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -395,7 +395,7 @@ typeToAnnotation qualify namespace type_ =
                 |> CliMonad.map
                     (\ann ->
                         if qualify then
-                            Elm.Annotation.namedWith (namespace ++ [ Common.moduleToString Common.Types ])
+                            Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types)
                                 "Nullable"
                                 [ ann ]
 
@@ -432,7 +432,7 @@ typeToAnnotation qualify namespace type_ =
         Common.Ref ref ->
             CliMonad.map
                 (if qualify then
-                    Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ])
+                    Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types)
 
                  else
                     Elm.Annotation.named []
@@ -479,7 +479,7 @@ typeToAnnotationMaybe qualify namespace type_ =
         Common.Ref ref ->
             CliMonad.map
                 (if qualify then
-                    Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ])
+                    Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types)
 
                  else
                     Elm.Annotation.named []
@@ -602,7 +602,7 @@ typeToEncoder qualify namespace type_ =
                     (\encoder nullableValue ->
                         Elm.Case.custom
                             nullableValue
-                            (Elm.Annotation.namedWith (namespace ++ [ Common.moduleToString Common.Types ]) "Nullable" [ Elm.Annotation.var "value" ])
+                            (Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types) "Nullable" [ Elm.Annotation.var "value" ])
                             [ Elm.Case.branch0 "Null" Gen.Json.Encode.null
                             , Elm.Case.branch1 "Present"
                                 ( "value", Elm.Annotation.var "value" )
@@ -620,7 +620,7 @@ typeToEncoder qualify namespace type_ =
                         (Elm.value
                             { importFrom =
                                 if qualify then
-                                    namespace ++ [ Common.moduleToString Common.Json ]
+                                    Common.moduleToNamespace namespace Common.Json
 
                                 else
                                     []
@@ -648,7 +648,7 @@ typeToEncoder qualify namespace type_ =
                 |> CliMonad.map
                     (\branches rec ->
                         Elm.Case.custom rec
-                            (Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ]) oneOfName)
+                            (Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) oneOfName)
                             branches
                     )
 
@@ -664,7 +664,7 @@ oneOfAnnotation : Bool -> List String -> Common.TypeName -> Common.OneOfData -> 
 oneOfAnnotation qualify namespace oneOfName oneOfData =
     Elm.Annotation.named
         (if qualify then
-            namespace ++ [ Common.moduleToString Common.Types ]
+            Common.moduleToNamespace namespace Common.Types
 
          else
             []
@@ -702,7 +702,7 @@ typeToDecoder qualify namespace type_ =
                                     (Elm.value
                                         { importFrom =
                                             if qualify then
-                                                namespace ++ [ Common.moduleToString Common.Json ]
+                                                Common.moduleToNamespace namespace Common.Json
 
                                             else
                                                 []
@@ -716,7 +716,7 @@ typeToDecoder qualify namespace type_ =
                                       else
                                         decodeOptionalField.callFrom
                                             (if qualify then
-                                                namespace ++ [ Common.moduleToString Common.Json ]
+                                                Common.moduleToNamespace namespace Common.Json
 
                                              else
                                                 []
@@ -775,7 +775,7 @@ typeToDecoder qualify namespace type_ =
                     Gen.Json.Decode.oneOf
                         [ Gen.Json.Decode.call_.map
                             (Elm.value
-                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                 , name = "Present"
                                 , annotation = Nothing
                                 }
@@ -783,7 +783,7 @@ typeToDecoder qualify namespace type_ =
                             decoder
                         , Gen.Json.Decode.null
                             (Elm.value
-                                { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                { importFrom = Common.moduleToNamespace namespace Common.Types
                                 , name = "Null"
                                 , annotation = Nothing
                                 }
@@ -798,7 +798,7 @@ typeToDecoder qualify namespace type_ =
                     Elm.value
                         { importFrom =
                             if qualify then
-                                namespace ++ [ Common.moduleToString Common.Json ]
+                                Common.moduleToNamespace namespace Common.Json
 
                             else
                                 []
@@ -816,7 +816,7 @@ typeToDecoder qualify namespace type_ =
                             |> CliMonad.map
                                 (Gen.Json.Decode.call_.map
                                     (Elm.value
-                                        { importFrom = namespace ++ [ Common.moduleToString Common.Types ]
+                                        { importFrom = Common.moduleToNamespace namespace Common.Types
                                         , name = toVariantName oneOfName variant.name
                                         , annotation = Nothing
                                         }
@@ -827,7 +827,7 @@ typeToDecoder qualify namespace type_ =
                     (\decoders ->
                         decoders
                             |> Gen.Json.Decode.oneOf
-                            |> Elm.withType (Elm.Annotation.named (namespace ++ [ Common.moduleToString Common.Types ]) oneOfName)
+                            |> Elm.withType (Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) oneOfName)
                     )
 
         Common.Bytes ->

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -394,15 +394,9 @@ typeToAnnotation qualify namespace type_ =
             typeToAnnotation qualify namespace t
                 |> CliMonad.map
                     (\ann ->
-                        if qualify then
-                            Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types)
-                                "Nullable"
-                                [ ann ]
-
-                        else
-                            Elm.Annotation.namedWith []
-                                "Nullable"
-                                [ ann ]
+                        Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Common)
+                            "Nullable"
+                            [ ann ]
                     )
 
         Common.Object fields ->
@@ -602,7 +596,7 @@ typeToEncoder qualify namespace type_ =
                     (\encoder nullableValue ->
                         Elm.Case.custom
                             nullableValue
-                            (Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Types) "Nullable" [ Elm.Annotation.var "value" ])
+                            (Elm.Annotation.namedWith (Common.moduleToNamespace namespace Common.Common) "Nullable" [ Elm.Annotation.var "value" ])
                             [ Elm.Case.branch0 "Null" Gen.Json.Encode.null
                             , Elm.Case.branch1 "Present"
                                 ( "value", Elm.Annotation.var "value" )
@@ -775,7 +769,7 @@ typeToDecoder qualify namespace type_ =
                     Gen.Json.Decode.oneOf
                         [ Gen.Json.Decode.call_.map
                             (Elm.value
-                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                 , name = "Present"
                                 , annotation = Nothing
                                 }
@@ -783,7 +777,7 @@ typeToDecoder qualify namespace type_ =
                             decoder
                         , Gen.Json.Decode.null
                             (Elm.value
-                                { importFrom = Common.moduleToNamespace namespace Common.Types
+                                { importFrom = Common.moduleToNamespace namespace Common.Common
                                 , name = "Null"
                                 , annotation = Nothing
                                 }

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -694,12 +694,7 @@ typeToDecoder qualify namespace type_ =
                             Elm.Op.pipe
                                 (Elm.apply
                                     (Elm.value
-                                        { importFrom =
-                                            if qualify then
-                                                Common.moduleToNamespace namespace Common.Json
-
-                                            else
-                                                []
+                                        { importFrom = Common.moduleToNamespace namespace Common.Common
                                         , name = "jsonDecodeAndMap"
                                         , annotation = Nothing
                                         }
@@ -709,12 +704,7 @@ typeToDecoder qualify namespace type_ =
 
                                       else
                                         decodeOptionalField.callFrom
-                                            (if qualify then
-                                                Common.moduleToNamespace namespace Common.Json
-
-                                             else
-                                                []
-                                            )
+                                            (Common.moduleToNamespace namespace Common.Common)
                                             (Elm.string key)
                                             internalDecoder
                                     ]


### PR DESCRIPTION
This is a commit such that the example compiles, but it's a terrible workaround that just changes one name clash for an eventual new name clash in the future.

I don't have a great idea, possibly we should just rename types if they're called "Error" in the OAS?