### PR TITLE
Better groups

### DIFF
--- a/src/JsonSchema/Generate.elm
+++ b/src/JsonSchema/Generate.elm
@@ -29,7 +29,7 @@ schemaToDeclarations namespace name schema =
                       , Elm.alias typeName ann
                             |> Elm.exposeWith
                                 { exposeConstructor = False
-                                , group = Nothing
+                                , group = Just "Aliases"
                                 }
                       )
                         |> CliMonad.succeed

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -147,14 +147,14 @@ files { namespace, generateTodos, effectTypes, server } apiSpec =
                                  , customHttpError
                                     |> Elm.exposeWith
                                         { exposeConstructor = True
-                                        , group = Nothing
+                                        , group = Just "Http"
                                         }
                                  )
                                , ( Common.Common
                                  , nullableType
                                     |> Elm.exposeWith
                                         { exposeConstructor = True
-                                        , group = Nothing
+                                        , group = Just "Types"
                                         }
                                  )
                                ]
@@ -344,7 +344,7 @@ unitDeclarations namespace name =
           , Elm.alias typeName Elm.Annotation.unit
                 |> Elm.exposeWith
                     { exposeConstructor = False
-                    , group = Nothing
+                    , group = Just "Aliases"
                     }
           )
             |> CliMonad.succeed
@@ -673,7 +673,7 @@ toRequestFunctions server effectTypes namespace method pathUrl operation =
                                                         |> Elm.withDocumentation (documentation auth)
                                                         |> Elm.exposeWith
                                                             { exposeConstructor = False
-                                                            , group = Nothing
+                                                            , group = Just "Operations"
                                                             }
                                                     )
                                                 )
@@ -1659,7 +1659,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                         Elm.alias errorName Elm.Annotation.unit
                                             |> Elm.exposeWith
                                                 { exposeConstructor = True
-                                                , group = Nothing
+                                                , group = Just "Errors"
                                                 }
 
                                       else
@@ -1669,7 +1669,7 @@ operationToTypesExpectAndResolver namespace functionName operation =
                                             |> Elm.customType errorName
                                             |> Elm.exposeWith
                                                 { exposeConstructor = True
-                                                , group = Nothing
+                                                , group = Just "Errors"
                                                 }
                                     , Elm.Annotation.named (Common.moduleToNamespace namespace Common.Types) errorName
                                     )

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -366,7 +366,7 @@ oneOfDeclaration namespace ( oneOfName, variants ) =
                     |> Elm.customType oneOfName
                     |> Elm.exposeWith
                         { exposeConstructor = True
-                        , group = Nothing
+                        , group = Just "One of"
                         }
                 )
             )


### PR DESCRIPTION
The group for APIs is taken from tags, for other functions and types it's just a couple of default ones.

I don't like the "One of" group, open to suggestions.