### PR TITLE
Generate documentation for types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+-   Add documentation for generated types. [Leonardo Taglialegne](https://github.com/miniBill)
+
 ## [0.6.1] - 2024-07-23
 
 ### Fixed

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -203,6 +203,7 @@ type alias OneOfData =
     List
         { name : VariantName
         , type_ : Type
+        , documentation : Maybe String
         }
 
 
@@ -221,6 +222,7 @@ type alias FieldName =
 type alias Field =
     { type_ : Type
     , required : Bool
+    , documentation : Maybe String
     }
 
 


### PR DESCRIPTION
This is not complete, but it does generate docs for most type.

The biggest missing piece is top level custom types, but now the infrastructure is in place for tackling those too (probably in a separate PR).