### PR TITLE
Prepare format separation

### DIFF
--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -692,11 +692,9 @@ defaultFormats =
 
 dateTimeFormat : CliMonad.Format
 dateTimeFormat =
-    { basicType = Common.String
-    , format = "date-time"
-    , annotation = Gen.Time.annotation_.posix
-    , encode =
-        \instant ->
+    let
+        toString : Elm.Expression -> Elm.Expression
+        toString instant =
             Gen.Rfc3339.make_.dateTimeOffset
                 (Elm.record
                     [ ( "instant", instant )
@@ -709,6 +707,14 @@ dateTimeFormat =
                     ]
                 )
                 |> Gen.Rfc3339.toString
+    in
+    { basicType = Common.String
+    , format = "date-time"
+    , annotation = Gen.Time.annotation_.posix
+    , encode =
+        \instant ->
+            instant
+                |> toString
                 |> Gen.Json.Encode.call_.string
     , decoder =
         Gen.Json.Decode.string
@@ -722,6 +728,7 @@ dateTimeFormat =
                         , err = \_ -> Gen.Json.Decode.fail "Invalid RFC-3339 date-time"
                         }
                 )
+    , toParamString = toString
     , sharedDeclarations = []
     , requiresPackages = []
     }
@@ -737,6 +744,7 @@ dateFormat =
             date
                 |> Gen.Date.toIsoString
                 |> Gen.Json.Encode.call_.string
+    , toParamString = Gen.Date.toIsoString
     , decoder =
         Gen.Json.Decode.string
             |> Gen.Json.Decode.andThen
@@ -759,6 +767,7 @@ defaultStringFormat format =
     , annotation = Elm.Annotation.string
     , encode = Gen.Json.Encode.call_.string
     , decoder = Gen.Json.Decode.string
+    , toParamString = identity
     , sharedDeclarations = []
     , requiresPackages = []
     }

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -10,10 +10,10 @@ import Cli.Option
 import Cli.OptionsParser
 import Cli.Program
 import CliMonad
+import Common
 import Dict
 import Elm
 import Elm.Annotation
-import FastDict
 import FatalError
 import Gen.Date
 import Gen.Json.Decode
@@ -682,18 +682,19 @@ generateFileFromOpenApiSpec config apiSpec =
         |> BackendTask.fromResult
 
 
-defaultFormats : FastDict.Dict CliMonad.FormatName CliMonad.Format
+defaultFormats : List CliMonad.Format
 defaultFormats =
-    [ ( ( "string", "date-time" ), dateTimeFormat )
-    , ( ( "string", "date" ), dateFormat )
-    , ( ( "string", "password" ), defaultStringFormat )
+    [ dateTimeFormat
+    , dateFormat
+    , defaultStringFormat "password"
     ]
-        |> FastDict.fromList
 
 
 dateTimeFormat : CliMonad.Format
 dateTimeFormat =
-    { annotation = Gen.Time.annotation_.posix
+    { basicType = Common.String
+    , format = "date-time"
+    , annotation = Gen.Time.annotation_.posix
     , encode =
         \instant ->
             Gen.Rfc3339.make_.dateTimeOffset
@@ -728,7 +729,9 @@ dateTimeFormat =
 
 dateFormat : CliMonad.Format
 dateFormat =
-    { annotation = Gen.Date.annotation_.date
+    { basicType = Common.String
+    , format = "date"
+    , annotation = Gen.Date.annotation_.date
     , encode =
         \date ->
             date
@@ -749,9 +752,11 @@ dateFormat =
     }
 
 
-defaultStringFormat : CliMonad.Format
-defaultStringFormat =
-    { annotation = Elm.Annotation.string
+defaultStringFormat : String -> CliMonad.Format
+defaultStringFormat format =
+    { basicType = Common.String
+    , format = format
+    , annotation = Elm.Annotation.string
     , encode = Gen.Json.Encode.call_.string
     , decoder = Gen.Json.Decode.string
     , sharedDeclarations = []

--- a/src/CliMonad.elm
+++ b/src/CliMonad.elm
@@ -58,6 +58,7 @@ type alias Format =
     , format : String
     , encode : Elm.Expression -> Elm.Expression
     , decoder : Elm.Expression
+    , toParamString : Elm.Expression -> Elm.Expression
     , annotation : Elm.Annotation.Annotation
     , sharedDeclarations : List Elm.Declaration
     , requiresPackages : List String
@@ -67,6 +68,7 @@ type alias Format =
 type alias InternalFormat =
     { encode : Elm.Expression -> Elm.Expression
     , decoder : Elm.Expression
+    , toParamString : Elm.Expression -> Elm.Expression
     , annotation : Elm.Annotation.Annotation
     , sharedDeclarations : List Elm.Declaration
     , requiresPackages : List String
@@ -265,6 +267,7 @@ toInternalFormat format =
     ( ( Common.basicTypeToString format.basicType, format.format )
     , { encode = format.encode
       , decoder = format.decoder
+      , toParamString = format.toParamString
       , annotation = format.annotation
       , sharedDeclarations = format.sharedDeclarations
       , requiresPackages = format.requiresPackages
@@ -360,6 +363,7 @@ withFormat :
     ->
         ({ encode : Elm.Expression -> Elm.Expression
          , decoder : Elm.Expression
+         , toParamString : Elm.Expression -> Elm.Expression
          , annotation : Elm.Annotation.Annotation
          , sharedDeclarations : List Elm.Declaration
          , requiresPackages : List String

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -1,5 +1,7 @@
 module Common exposing
-    ( Field
+    ( BasicType(..)
+    , ConstValue(..)
+    , Field
     , Module(..)
     , Object
     , OneOfData
@@ -8,6 +10,7 @@ module Common exposing
     , TypeName
     , UnsafeName(..)
     , VariantName
+    , basicTypeToString
     , enum
     , moduleToNamespace
     , ref
@@ -275,10 +278,12 @@ initialUppercaseWordToLowercase input =
 type Type
     = Nullable Type
     | Object Object
-    | String { const : Maybe String, format : Maybe String }
-    | Int { const : Maybe Int }
-    | Float { const : Maybe Float }
-    | Bool { const : Maybe Bool }
+    | Basic
+        -- This is separate for easier pattern matching
+        BasicType
+        { format : Maybe String
+        , const : Maybe ConstValue
+        }
     | Null
     | List Type
     | OneOf TypeName OneOfData
@@ -287,6 +292,36 @@ type Type
     | Ref (List String)
     | Bytes
     | Unit
+
+
+type BasicType
+    = Integer
+    | Boolean
+    | String
+    | Number
+
+
+type ConstValue
+    = ConstInteger Int
+    | ConstBoolean Bool
+    | ConstString String
+    | ConstNumber Float
+
+
+basicTypeToString : BasicType -> String
+basicTypeToString basicType =
+    case basicType of
+        Integer ->
+            "integer"
+
+        Boolean ->
+            "boolean"
+
+        String ->
+            "string"
+
+        Number ->
+            "number"
 
 
 type alias Object =

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -275,7 +275,7 @@ initialUppercaseWordToLowercase input =
 type Type
     = Nullable Type
     | Object Object
-    | String { const : Maybe String }
+    | String { const : Maybe String, format : Maybe String }
     | Int { const : Maybe Int }
     | Float { const : Maybe Float }
     | Bool { const : Maybe Bool }
@@ -287,8 +287,6 @@ type Type
     | Ref (List String)
     | Bytes
     | Unit
-    | Date
-    | DateTime
 
 
 type alias Object =

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -2096,8 +2096,12 @@ paramToString qualify type_ =
                 \{ inputToString, alwaysJust } val ->
                     if alwaysJust then
                         case p of
-                            Common.Basic Common.String _ ->
-                                val
+                            Common.Basic Common.String { format } ->
+                                if format == Nothing then
+                                    val
+
+                                else
+                                    Gen.Maybe.call_.map inputToString val
 
                             _ ->
                                 Gen.Maybe.call_.map inputToString val

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -2706,9 +2706,7 @@ outerExpectJsonCustom name f =
         ( "toMsg"
         , Just
             (Elm.Annotation.function
-                [ Gen.Result.annotation_.result
-                    (Elm.Annotation.namedWith [] "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ])
-                    (Elm.Annotation.var "success")
+                [ Gen.Result.annotation_.result errorAnnotation (Elm.Annotation.var "success")
                 ]
                 (Elm.Annotation.var "msg")
             )
@@ -2726,6 +2724,11 @@ outerExpectJsonCustom name f =
         f
 
 
+errorAnnotation : Elm.Annotation.Annotation
+errorAnnotation =
+    Elm.Annotation.namedWith [] "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ]
+
+
 outerExpectStringCustom :
     String
     -> (Elm.Expression -> Elm.Expression -> Elm.Expression)
@@ -2740,10 +2743,7 @@ outerExpectStringCustom name f =
         ( "toMsg"
         , Just
             (Elm.Annotation.function
-                [ Gen.Result.annotation_.result
-                    (Elm.Annotation.namedWith [] "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ])
-                    Elm.Annotation.string
-                ]
+                [ Gen.Result.annotation_.result errorAnnotation Elm.Annotation.string ]
                 (Elm.Annotation.var "msg")
             )
         )
@@ -2964,7 +2964,7 @@ jsonResolverCustom =
                         (innerExpectJsonCustom errorDecoders successDecoder)
             in
             Gen.Http.stringResolver toResult
-                |> Elm.withType (Gen.Http.annotation_.resolver (Elm.Annotation.namedWith [] "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ]) (Elm.Annotation.var "success"))
+                |> Elm.withType (Gen.Http.annotation_.resolver errorAnnotation (Elm.Annotation.var "success"))
 
 
 jsonResolverCustomEffect :
@@ -2983,7 +2983,7 @@ jsonResolverCustomEffect =
                         (innerExpectJsonCustom errorDecoders successDecoder)
             in
             Gen.Effect.Http.stringResolver toResult
-                |> Elm.withType (Gen.Effect.Http.annotation_.resolver (Elm.Annotation.var "restrictions") (Elm.Annotation.namedWith [] "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ]) (Elm.Annotation.var "success"))
+                |> Elm.withType (Gen.Effect.Http.annotation_.resolver (Elm.Annotation.var "restrictions") errorAnnotation (Elm.Annotation.var "success"))
 
 
 bytesResolverCustom :
@@ -3040,7 +3040,7 @@ stringResolverCustom =
                         (innerExpectRawCustom identity errorDecoders)
             in
             Gen.Http.stringResolver toResult
-                |> Elm.withType (Gen.Http.annotation_.resolver (Elm.Annotation.namedWith [] "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ]) Elm.Annotation.string)
+                |> Elm.withType (Gen.Http.annotation_.resolver errorAnnotation Elm.Annotation.string)
 
 
 stringResolverCustomEffect :
@@ -3059,7 +3059,7 @@ stringResolverCustomEffect =
                         (innerExpectRawCustom identity errorDecoders)
             in
             Gen.Effect.Http.stringResolver toResult
-                |> Elm.withType (Gen.Effect.Http.annotation_.resolver (Elm.Annotation.var "restrictions") (Elm.Annotation.namedWith [] "Error" [ Elm.Annotation.var "err", Elm.Annotation.string ]) Elm.Annotation.string)
+                |> Elm.withType (Gen.Effect.Http.annotation_.resolver (Elm.Annotation.var "restrictions") errorAnnotation Elm.Annotation.string)
 
 
 bytesToString : Elm.Expression -> Elm.Expression

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -116,10 +116,11 @@ files :
     , generateTodos : Bool
     , effectTypes : List EffectType
     , server : Server
+    , formats : FastDict.Dict CliMonad.FormatName CliMonad.Format
     }
     -> OpenApi.OpenApi
     -> Result CliMonad.Message ( List Elm.File, List CliMonad.Message )
-files { namespace, generateTodos, effectTypes, server } apiSpec =
+files { namespace, generateTodos, effectTypes, server, formats } apiSpec =
     case extractEnums apiSpec of
         Err e ->
             Err e
@@ -138,6 +139,7 @@ files { namespace, generateTodos, effectTypes, server } apiSpec =
                     , generateTodos = generateTodos
                     , enums = enums
                     , namespace = namespace
+                    , formats = formats
                     }
                 |> Result.map
                     (\( decls, warnings ) ->
@@ -2563,7 +2565,7 @@ operationToTypesExpectAndResolver functionName operation =
                                         StringContent _ ->
                                             CliMonad.map2
                                                 (\errorDecoders_ ( errorTypeDeclaration_, errorTypeAnnotation ) ->
-                                                    { successType = Common.String { const = Nothing }
+                                                    { successType = Common.String { const = Nothing, format = Nothing }
                                                     , bodyTypeAnnotation = Elm.Annotation.string
                                                     , errorTypeDeclaration = errorTypeDeclaration_
                                                     , errorTypeAnnotation = errorTypeAnnotation

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -661,6 +661,13 @@ toRequestFunctions server effectTypes method pathUrl operation =
                 |> makeNamespaceValid
                 |> removeInvalidChars
                 |> String.Extra.camelize
+                |> (\n ->
+                        if String.isEmpty n then
+                            "root"
+
+                        else
+                            n
+                   )
 
         isSinglePackage : Bool
         isSinglePackage =

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -1,6 +1,7 @@
 module Test.OpenApi.Generate exposing (suite)
 
 import Char
+import Cli
 import CliMonad
 import Elm
 import Expect
@@ -78,6 +79,7 @@ suite =
                                     , generateTodos = False
                                     , effectTypes = [ OpenApi.Generate.ElmHttpCmd, OpenApi.Generate.ElmHttpTask ]
                                     , server = OpenApi.Generate.Default
+                                    , formats = Cli.defaultFormats
                                     }
                                     oas
                         in


### PR DESCRIPTION
This doesn't implement the shared declarations nor the required packages nor any config, it just separates out the format handling at the top level with the new API