### PR TITLE
Separate configuration

### DIFF
--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -51,7 +51,7 @@ config =
     , NoUnused.CustomTypeConstructorArgs.rule
     , NoUnused.Dependencies.rule
     , NoUnused.Exports.rule
-        |> Rule.ignoreErrorsForFiles [ "src/Cli.elm" ]
+        |> Rule.ignoreErrorsForFiles [ "src/Cli.elm", "src/OpenApi/Config.elm" ]
     , NoUnused.Parameters.rule
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -285,7 +285,7 @@ run =
 type alias Config =
     { oasPath : PathType
     , outputDirectory : String
-    , outputModuleName : Maybe String
+    , outputModuleName : Maybe (List String)
     , effectTypes : List OpenApi.Generate.EffectType
     , generateTodos : Bool
     , autoConvertSwagger : Bool
@@ -302,7 +302,7 @@ parseCliOptions cliOptions =
     BackendTask.succeed
         { oasPath = cliOptions.entryFilePath
         , outputDirectory = cliOptions.outputDirectory
-        , outputModuleName = cliOptions.outputModuleName
+        , outputModuleName = Maybe.map (String.split ".") cliOptions.outputModuleName
         , effectTypes = cliOptions.effectTypes
         , generateTodos = cliOptions.generateTodos
         , autoConvertSwagger = cliOptions.autoConvertSwagger
@@ -692,7 +692,7 @@ yamlToJsonValueDecoder =
 
 
 generateFileFromOpenApiSpec :
-    { outputModuleName : Maybe String
+    { outputModuleName : Maybe (List String)
     , generateTodos : Bool
     , effectTypes : List OpenApi.Generate.EffectType
     , server : OpenApi.Generate.Server
@@ -712,7 +712,7 @@ generateFileFromOpenApiSpec config apiSpec =
         moduleName =
             case config.outputModuleName of
                 Just modName ->
-                    String.split "." modName
+                    modName
 
                 Nothing ->
                     apiSpec

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -294,6 +294,7 @@ type alias Config =
     , server : OpenApi.Generate.Server
     , overrides : List PathType
     , writeMergedTo : Maybe String
+    , formats : List CliMonad.Format
     }
 
 
@@ -313,6 +314,7 @@ parseCliOptions cliOptions =
         , server = cliOptions.server
         , overrides = cliOptions.overrides
         , writeMergedTo = cliOptions.writeMergedTo
+        , formats = defaultFormats
         }
 
 
@@ -364,6 +366,7 @@ script config =
                 , generateTodos = config.generateTodos
                 , effectTypes = config.effectTypes
                 , server = config.server
+                , formats = config.formats
                 }
             )
         |> Pages.Script.Spinner.withStep "Format with elm-format" (onFirst attemptToFormat)
@@ -696,6 +699,7 @@ generateFileFromOpenApiSpec :
     , generateTodos : Bool
     , effectTypes : List OpenApi.Generate.EffectType
     , server : OpenApi.Generate.Server
+    , formats : List CliMonad.Format
     }
     -> OpenApi.OpenApi
     ->
@@ -727,7 +731,7 @@ generateFileFromOpenApiSpec config apiSpec =
         , generateTodos = config.generateTodos
         , effectTypes = config.effectTypes
         , server = config.server
-        , formats = defaultFormats
+        , formats = config.formats
         }
         apiSpec
         |> Result.mapError (messageToString >> FatalError.fromString)

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -1,4 +1,4 @@
-module Cli exposing (run)
+module Cli exposing (run, withConfig)
 
 import Ansi
 import Ansi.Color
@@ -268,7 +268,7 @@ run =
         (\cliOptions ->
             cliOptions
                 |> parseCliOptions
-                |> script
+                |> withConfig
         )
 
 
@@ -301,8 +301,8 @@ parseCliOptions cliOptions =
     }
 
 
-script : OpenApi.Config.Config -> BackendTask FatalError ()
-script config =
+withConfig : OpenApi.Config.Config -> BackendTask FatalError ()
+withConfig config =
     Pages.Script.Spinner.steps
         |> (case config.oasPath of
                 OpenApi.Config.Url url ->

--- a/src/CliMonad.elm
+++ b/src/CliMonad.elm
@@ -7,7 +7,7 @@ module CliMonad exposing
     , errorToWarning, fromApiSpec, enumName, moduleToNamespace
     , withPath, withWarning, withRequiredPackage
     , todo, todoWithDefault
-    , Format, withFormat
+    , withFormat
     )
 
 {-|
@@ -20,7 +20,7 @@ module CliMonad exposing
 @docs errorToWarning, fromApiSpec, enumName, moduleToNamespace
 @docs withPath, withWarning, withRequiredPackage
 @docs todo, todoWithDefault
-@docs Format, withFormat
+@docs withFormat
 
 -}
 
@@ -33,6 +33,7 @@ import FastDict
 import FastSet
 import Gen.Debug
 import OpenApi exposing (OpenApi)
+import OpenApi.Config
 import Regex exposing (Regex)
 
 
@@ -54,18 +55,6 @@ type alias OneOfName =
 -}
 type alias InternalFormatName =
     ( String, String )
-
-
-type alias Format =
-    { basicType : Common.BasicType
-    , format : String
-    , encode : Elm.Expression -> Elm.Expression
-    , decoder : Elm.Expression
-    , toParamString : Elm.Expression -> Elm.Expression
-    , annotation : Elm.Annotation.Annotation
-    , sharedDeclarations : List Elm.Declaration
-    , requiresPackages : List String
-    }
 
 
 type alias InternalFormat =
@@ -278,7 +267,7 @@ run :
         , generateTodos : Bool
         , enums : FastDict.Dict (List String) { name : Common.UnsafeName, documentation : Maybe String }
         , namespace : List String
-        , formats : List Format
+        , formats : List OpenApi.Config.Format
         }
     -> CliMonad (List ( Common.Module, Elm.Declaration ))
     ->
@@ -335,7 +324,7 @@ run oneOfDeclarations input (CliMonad x) =
             )
 
 
-toInternalFormat : Format -> ( InternalFormatName, InternalFormat )
+toInternalFormat : OpenApi.Config.Format -> ( InternalFormatName, InternalFormat )
 toInternalFormat format =
     ( ( Common.basicTypeToString format.basicType, format.format )
     , { encode = format.encode

--- a/src/OpenApi/Config.elm
+++ b/src/OpenApi/Config.elm
@@ -1,0 +1,46 @@
+module OpenApi.Config exposing (Config, PathType(..), pathTypeFromString, pathTypeToString)
+
+import CliMonad
+import OpenApi.Generate
+import Url
+
+
+type alias Config =
+    { oasPath : PathType
+    , outputDirectory : String
+    , outputModuleName : Maybe (List String)
+    , effectTypes : List OpenApi.Generate.EffectType
+    , generateTodos : Bool
+    , autoConvertSwagger : Bool
+    , swaggerConversionUrl : String
+    , swaggerConversionCommand : Maybe { command : String, args : List String }
+    , server : OpenApi.Generate.Server
+    , overrides : List PathType
+    , writeMergedTo : Maybe String
+    , formats : List CliMonad.Format
+    }
+
+
+pathTypeFromString : String -> PathType
+pathTypeFromString path =
+    case Url.fromString path of
+        Just url ->
+            Url url
+
+        Nothing ->
+            File path
+
+
+pathTypeToString : PathType -> String
+pathTypeToString pathType =
+    case pathType of
+        File file ->
+            file
+
+        Url url ->
+            Url.toString url
+
+
+type PathType
+    = File String -- swagger.json ./swagger.json /folder/swagger.json
+    | Url Url.Url -- https://petstore3.swagger.io/api/v3/openapi.json

--- a/src/OpenApi/Config.elm
+++ b/src/OpenApi/Config.elm
@@ -1,12 +1,22 @@
-module OpenApi.Config exposing (Config, PathType(..), pathTypeFromString, pathTypeToString)
+module OpenApi.Config exposing (Config, Path(..), defaultFormats, init, pathFromString, pathToString)
 
 import CliMonad
+import Common
+import Elm
+import Elm.Annotation
+import Gen.Date
+import Gen.Json.Decode
+import Gen.Json.Encode
+import Gen.Parser.Advanced
+import Gen.Result
+import Gen.Rfc3339
+import Gen.Time
 import OpenApi.Generate
 import Url
 
 
 type alias Config =
-    { oasPath : PathType
+    { oasPath : Path
     , outputDirectory : String
     , outputModuleName : Maybe (List String)
     , effectTypes : List OpenApi.Generate.EffectType
@@ -15,14 +25,14 @@ type alias Config =
     , swaggerConversionUrl : String
     , swaggerConversionCommand : Maybe { command : String, args : List String }
     , server : OpenApi.Generate.Server
-    , overrides : List PathType
+    , overrides : List Path
     , writeMergedTo : Maybe String
     , formats : List CliMonad.Format
     }
 
 
-pathTypeFromString : String -> PathType
-pathTypeFromString path =
+pathFromString : String -> Path
+pathFromString path =
     case Url.fromString path of
         Just url ->
             Url url
@@ -31,8 +41,8 @@ pathTypeFromString path =
             File path
 
 
-pathTypeToString : PathType -> String
-pathTypeToString pathType =
+pathToString : Path -> String
+pathToString pathType =
     case pathType of
         File file ->
             file
@@ -41,6 +51,119 @@ pathTypeToString pathType =
             Url.toString url
 
 
-type PathType
+type Path
     = File String -- swagger.json ./swagger.json /folder/swagger.json
     | Url Url.Url -- https://petstore3.swagger.io/api/v3/openapi.json
+
+
+init : Path -> String -> Config
+init oasPath outputDirectory =
+    { oasPath = oasPath
+    , outputDirectory = outputDirectory
+    , outputModuleName = Nothing
+    , effectTypes = []
+    , generateTodos = False
+    , autoConvertSwagger = False
+    , swaggerConversionUrl = "https://converter.swagger.io/api/convert"
+    , swaggerConversionCommand = Nothing
+    , server = OpenApi.Generate.Default
+    , overrides = []
+    , writeMergedTo = Nothing
+    , formats = defaultFormats
+    }
+
+
+defaultFormats : List CliMonad.Format
+defaultFormats =
+    [ dateTimeFormat
+    , dateFormat
+    , defaultStringFormat "password"
+    ]
+
+
+dateTimeFormat : CliMonad.Format
+dateTimeFormat =
+    let
+        toString : Elm.Expression -> Elm.Expression
+        toString instant =
+            Gen.Rfc3339.make_.dateTimeOffset
+                (Elm.record
+                    [ ( "instant", instant )
+                    , ( "offset"
+                      , Elm.record
+                            [ ( "hour", Elm.int 0 )
+                            , ( "minute", Elm.int 0 )
+                            ]
+                      )
+                    ]
+                )
+                |> Gen.Rfc3339.toString
+    in
+    { basicType = Common.String
+    , format = "date-time"
+    , annotation = Gen.Time.annotation_.posix
+    , encode =
+        \instant ->
+            instant
+                |> toString
+                |> Gen.Json.Encode.call_.string
+    , decoder =
+        Gen.Json.Decode.string
+            |> Gen.Json.Decode.andThen
+                (\raw ->
+                    Gen.Result.caseOf_.result
+                        (Gen.Parser.Advanced.call_.run Gen.Rfc3339.dateTimeOffsetParser raw)
+                        { ok = \record -> Gen.Json.Decode.succeed (Elm.get "instant" record)
+
+                        -- TODO: improve error message
+                        , err = \_ -> Gen.Json.Decode.fail "Invalid RFC-3339 date-time"
+                        }
+                )
+    , toParamString = toString
+    , sharedDeclarations = []
+    , requiresPackages =
+        [ "elm/parser"
+        , "elm/time"
+        , "justinmimbs/time-extra"
+        , "wolfadex/elm-rfc3339"
+        ]
+    }
+
+
+dateFormat : CliMonad.Format
+dateFormat =
+    { basicType = Common.String
+    , format = "date"
+    , annotation = Gen.Date.annotation_.date
+    , encode =
+        \date ->
+            date
+                |> Gen.Date.toIsoString
+                |> Gen.Json.Encode.call_.string
+    , toParamString = Gen.Date.toIsoString
+    , decoder =
+        Gen.Json.Decode.string
+            |> Gen.Json.Decode.andThen
+                (\raw ->
+                    Gen.Result.caseOf_.result
+                        (Gen.Date.call_.fromIsoString raw)
+                        { ok = Gen.Json.Decode.succeed
+                        , err = Gen.Json.Decode.call_.fail
+                        }
+                )
+    , sharedDeclarations = []
+    , requiresPackages = [ "justinmimbs/date" ]
+    }
+
+
+defaultStringFormat : String -> CliMonad.Format
+defaultStringFormat format =
+    { basicType = Common.String
+    , format = format
+    , annotation = Elm.Annotation.string
+    , encode = Gen.Json.Encode.call_.string
+    , decoder = Gen.Json.Decode.string
+    , toParamString = identity
+    , sharedDeclarations = []
+    , requiresPackages = []
+    }

--- a/src/OpenApi/Config.elm
+++ b/src/OpenApi/Config.elm
@@ -1,4 +1,4 @@
-module OpenApi.Config exposing (Config, EffectType(..), Format, Path(..), Server(..), autoConvertSwagger, defaultFormats, init, oasPath, outputDirectory, overrides, pathFromString, pathToString, swaggerConversionCommand, swaggerConversionUrl, toGenerationConfig, withAutoConvertSwagger, withEffectTypes, withGenerateTodos, withOutputModuleName, withOverrides, withServer, withSwaggerConversionCommand, withSwaggerConversionUrl, withWriteMergedTo, writeMergedTo)
+module OpenApi.Config exposing (Config, EffectType(..), Format, Path(..), Server(..), autoConvertSwagger, defaultFormats, init, oasPath, outputDirectory, overrides, pathFromString, pathToString, swaggerConversionCommand, swaggerConversionUrl, toGenerationConfig, withAutoConvertSwagger, withEffectTypes, withFormat, withGenerateTodos, withOutputModuleName, withOverrides, withServer, withSwaggerConversionCommand, withSwaggerConversionUrl, withWriteMergedTo, writeMergedTo)
 
 import Common
 import Dict
@@ -248,6 +248,11 @@ withServer newServer (Config config) =
 withWriteMergedTo : String -> Config -> Config
 withWriteMergedTo newWriteMergedTo (Config config) =
     Config { config | writeMergedTo = Just newWriteMergedTo }
+
+
+withFormat : Format -> Config -> Config
+withFormat newFormat (Config config) =
+    Config { config | formats = newFormat :: config.formats }
 
 
 swaggerConversionUrl : Config -> String

--- a/src/OpenApi/Config.elm
+++ b/src/OpenApi/Config.elm
@@ -1,4 +1,4 @@
-module OpenApi.Config exposing (Config, EffectType(..), Format, Path(..), Server(..), defaultFormats, init, pathFromString, pathToString)
+module OpenApi.Config exposing (Config, EffectType(..), Format, Path(..), Server(..), autoConvertSwagger, defaultFormats, init, oasPath, outputDirectory, overrides, pathFromString, pathToString, swaggerConversionCommand, swaggerConversionUrl, toGenerationConfig, withAutoConvertSwagger, withEffectTypes, withGenerateTodos, withOutputModuleName, withOverrides, withServer, withSwaggerConversionCommand, withSwaggerConversionUrl, withWriteMergedTo, writeMergedTo)
 
 import Common
 import Dict
@@ -14,20 +14,21 @@ import Gen.Time
 import Url
 
 
-type alias Config =
-    { oasPath : Path
-    , outputDirectory : String
-    , outputModuleName : Maybe (List String)
-    , effectTypes : List EffectType
-    , generateTodos : Bool
-    , autoConvertSwagger : Bool
-    , swaggerConversionUrl : String
-    , swaggerConversionCommand : Maybe { command : String, args : List String }
-    , server : Server
-    , overrides : List Path
-    , writeMergedTo : Maybe String
-    , formats : List Format
-    }
+type Config
+    = Config
+        { oasPath : Path
+        , outputDirectory : String
+        , outputModuleName : Maybe (List String)
+        , effectTypes : List EffectType
+        , generateTodos : Bool
+        , autoConvertSwagger : Bool
+        , swaggerConversionUrl : String
+        , swaggerConversionCommand : Maybe { command : String, args : List String }
+        , server : Server
+        , overrides : List Path
+        , writeMergedTo : Maybe String
+        , formats : List Format
+        }
 
 
 type EffectType
@@ -91,9 +92,9 @@ type Path
 
 
 init : Path -> String -> Config
-init oasPath outputDirectory =
-    { oasPath = oasPath
-    , outputDirectory = outputDirectory
+init initialOasPath initialOutputDirectory =
+    { oasPath = initialOasPath
+    , outputDirectory = initialOutputDirectory
     , outputModuleName = Nothing
     , effectTypes = [ ElmHttpCmd, ElmHttpTask ]
     , generateTodos = False
@@ -105,6 +106,7 @@ init oasPath outputDirectory =
     , writeMergedTo = Nothing
     , formats = defaultFormats
     }
+        |> Config
 
 
 defaultFormats : List Format
@@ -201,3 +203,101 @@ defaultStringFormat format =
     , sharedDeclarations = []
     , requiresPackages = []
     }
+
+
+withEffectTypes : List EffectType -> Config -> Config
+withEffectTypes effectTypes (Config config) =
+    Config { config | effectTypes = effectTypes }
+
+
+withOutputModuleName : List String -> Config -> Config
+withOutputModuleName moduleName (Config config) =
+    Config { config | outputModuleName = Just moduleName }
+
+
+withOverrides : List Path -> Config -> Config
+withOverrides newOverrides (Config config) =
+    Config { config | overrides = newOverrides }
+
+
+withGenerateTodos : Bool -> Config -> Config
+withGenerateTodos generateTodos (Config config) =
+    Config { config | generateTodos = generateTodos }
+
+
+withAutoConvertSwagger : Bool -> Config -> Config
+withAutoConvertSwagger newAutoConvertSwagger (Config config) =
+    Config { config | autoConvertSwagger = newAutoConvertSwagger }
+
+
+withSwaggerConversionUrl : String -> Config -> Config
+withSwaggerConversionUrl newSwaggerConversionUrl (Config config) =
+    Config { config | swaggerConversionUrl = newSwaggerConversionUrl }
+
+
+withSwaggerConversionCommand : { command : String, args : List String } -> Config -> Config
+withSwaggerConversionCommand newSwaggerConversionCommand (Config config) =
+    Config { config | swaggerConversionCommand = Just newSwaggerConversionCommand }
+
+
+withServer : Server -> Config -> Config
+withServer newServer (Config config) =
+    Config { config | server = newServer }
+
+
+withWriteMergedTo : String -> Config -> Config
+withWriteMergedTo newWriteMergedTo (Config config) =
+    Config { config | writeMergedTo = Just newWriteMergedTo }
+
+
+swaggerConversionUrl : Config -> String
+swaggerConversionUrl (Config config) =
+    config.swaggerConversionUrl
+
+
+swaggerConversionCommand : Config -> Maybe { command : String, args : List String }
+swaggerConversionCommand (Config config) =
+    config.swaggerConversionCommand
+
+
+autoConvertSwagger : Config -> Bool
+autoConvertSwagger (Config config) =
+    config.autoConvertSwagger
+
+
+oasPath : Config -> Path
+oasPath (Config config) =
+    config.oasPath
+
+
+toGenerationConfig :
+    Config
+    ->
+        { outputModuleName : Maybe (List String)
+        , generateTodos : Bool
+        , effectTypes : List EffectType
+        , server : Server
+        , formats : List Format
+        }
+toGenerationConfig (Config config) =
+    { outputModuleName = config.outputModuleName
+    , generateTodos = config.generateTodos
+    , effectTypes = config.effectTypes
+    , server = config.server
+    , formats = config.formats
+    }
+
+
+writeMergedTo : Config -> Maybe String
+writeMergedTo (Config config) =
+    config.writeMergedTo
+
+
+overrides : Config -> List Path
+overrides (Config config) =
+    config.overrides
+
+
+outputDirectory : Config -> String
+outputDirectory (Config config) =
+    config.outputDirectory

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -1,9 +1,7 @@
 module OpenApi.Generate exposing
     ( Config
     , ContentSchema(..)
-    , EffectType(..)
     , Mime
-    , Server(..)
     , files
     , sanitizeModuleName
     )
@@ -47,6 +45,7 @@ import List.Extra
 import List.NonEmpty
 import OpenApi
 import OpenApi.Components
+import OpenApi.Config
 import OpenApi.MediaType
 import OpenApi.Operation
 import OpenApi.Parameter
@@ -68,34 +67,11 @@ type alias Mime =
     String
 
 
-type EffectType
-    = ElmHttpCmd
-    | ElmHttpCmdRecord
-    | ElmHttpCmdRisky
-    | ElmHttpTask
-    | ElmHttpTaskRecord
-    | ElmHttpTaskRisky
-    | DillonkearnsElmPagesTask
-    | DillonkearnsElmPagesTaskRecord
-    | LamderaProgramTestCmd
-    | LamderaProgramTestCmdRisky
-    | LamderaProgramTestCmdRecord
-    | LamderaProgramTestTask
-    | LamderaProgramTestTaskRisky
-    | LamderaProgramTestTaskRecord
-
-
 type ContentSchema
     = EmptyContent
     | JsonContent Common.Type
     | StringContent Mime
     | BytesContent Mime
-
-
-type Server
-    = Default
-    | Single String
-    | Multiple (Dict.Dict String String)
 
 
 type alias AuthorizationInfo =
@@ -116,9 +92,9 @@ type alias PerPackage a =
 type alias Config =
     { namespace : List String
     , generateTodos : Bool
-    , effectTypes : List EffectType
-    , server : Server
-    , formats : List CliMonad.Format
+    , effectTypes : List OpenApi.Config.EffectType
+    , server : OpenApi.Config.Server
+    , formats : List OpenApi.Config.Format
     }
 
 
@@ -233,7 +209,7 @@ files { namespace, generateTodos, effectTypes, server, formats } apiSpec =
                     )
 
 
-elmHttpCommonDeclarations : List EffectType -> List ( Common.Module, Elm.Declaration )
+elmHttpCommonDeclarations : List OpenApi.Config.EffectType -> List ( Common.Module, Elm.Declaration )
 elmHttpCommonDeclarations effectTypes =
     if List.any (\effectType -> effectTypeToPackage effectType == Common.ElmHttp) effectTypes then
         [ ( Common.Common
@@ -284,7 +260,7 @@ elmHttpCommonDeclarations effectTypes =
         []
 
 
-lamderaProgramTestCommonDeclarations : List EffectType -> List ( Common.Module, Elm.Declaration )
+lamderaProgramTestCommonDeclarations : List OpenApi.Config.EffectType -> List ( Common.Module, Elm.Declaration )
 lamderaProgramTestCommonDeclarations effectTypes =
     if List.any (\effectType -> effectTypeToPackage effectType == Common.LamderaProgramTest) effectTypes then
         [ ( Common.Common
@@ -392,10 +368,10 @@ extractEnums openApi =
             (Ok FastDict.empty)
 
 
-serverDecls : OpenApi.OpenApi -> Server -> List ( Common.Module, Elm.Declaration )
+serverDecls : OpenApi.OpenApi -> OpenApi.Config.Server -> List ( Common.Module, Elm.Declaration )
 serverDecls apiSpec server =
     case server of
-        Multiple servers ->
+        OpenApi.Config.Multiple servers ->
             servers
                 |> Dict.toList
                 |> List.map
@@ -410,10 +386,10 @@ serverDecls apiSpec server =
                         )
                     )
 
-        Single _ ->
+        OpenApi.Config.Single _ ->
             []
 
-        Default ->
+        OpenApi.Config.Default ->
             case OpenApi.servers apiSpec of
                 [] ->
                     []
@@ -488,7 +464,7 @@ formatModuleDocs =
         )
 
 
-pathDeclarations : Server -> List EffectType -> CliMonad (List ( Common.Module, Elm.Declaration ))
+pathDeclarations : OpenApi.Config.Server -> List OpenApi.Config.EffectType -> CliMonad (List ( Common.Module, Elm.Declaration ))
 pathDeclarations server effectTypes =
     CliMonad.fromApiSpec OpenApi.paths
         |> CliMonad.andThen
@@ -666,7 +642,7 @@ requestBodyToDeclarations name reference =
                 |> CliMonad.withPath name
 
 
-toRequestFunctions : Server -> List EffectType -> String -> String -> OpenApi.Operation.Operation -> CliMonad (List ( Common.Module, Elm.Declaration ))
+toRequestFunctions : OpenApi.Config.Server -> List OpenApi.Config.EffectType -> String -> String -> OpenApi.Operation.Operation -> CliMonad (List ( Common.Module, Elm.Declaration ))
 toRequestFunctions server effectTypes method pathUrl operation =
     let
         functionName : String
@@ -853,7 +829,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                 declarationGroup :
                     AuthorizationInfo
                     -> (() -> a)
-                    -> List ( EffectType, a -> Elm.Declaration )
+                    -> List ( OpenApi.Config.EffectType, a -> Elm.Declaration )
                     -> List ( Common.Module, Elm.Declaration )
                 declarationGroup auth sharedData list =
                     if List.any (\( effectType, _ ) -> List.member effectType effectTypes) list then
@@ -935,7 +911,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     )
                             }
                         )
-                        [ ( ElmHttpCmd
+                        [ ( OpenApi.Config.ElmHttpCmd
                           , \{ cmdArg, cmdAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -943,7 +919,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     |> Elm.withType cmdAnnotation
                                     |> Elm.declaration functionName
                           )
-                        , ( ElmHttpCmdRisky
+                        , ( OpenApi.Config.ElmHttpCmdRisky
                           , \{ cmdArg, cmdAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -951,7 +927,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     |> Elm.withType cmdAnnotation
                                     |> Elm.declaration (functionName ++ "Risky")
                           )
-                        , ( ElmHttpCmdRecord
+                        , ( OpenApi.Config.ElmHttpCmdRecord
                           , \{ cmdArg, recordAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1011,7 +987,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     )
                             }
                         )
-                        [ ( ElmHttpTask
+                        [ ( OpenApi.Config.ElmHttpTask
                           , \{ taskArg, taskAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1019,7 +995,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     |> Elm.withType taskAnnotation
                                     |> Elm.declaration (functionName ++ "Task")
                           )
-                        , ( ElmHttpTaskRisky
+                        , ( OpenApi.Config.ElmHttpTaskRisky
                           , \{ taskArg, taskAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1027,7 +1003,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     |> Elm.withType taskAnnotation
                                     |> Elm.declaration (functionName ++ "TaskRisky")
                           )
-                        , ( ElmHttpTaskRecord
+                        , ( OpenApi.Config.ElmHttpTaskRecord
                           , \{ taskArg, recordAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1090,7 +1066,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     )
                             }
                         )
-                        [ ( DillonkearnsElmPagesTask
+                        [ ( OpenApi.Config.DillonkearnsElmPagesTask
                           , \{ taskArg, taskAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1098,7 +1074,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     |> Elm.withType taskAnnotation
                                     |> Elm.declaration functionName
                           )
-                        , ( DillonkearnsElmPagesTaskRecord
+                        , ( OpenApi.Config.DillonkearnsElmPagesTaskRecord
                           , \{ taskArg, recordAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1137,21 +1113,21 @@ toRequestFunctions server effectTypes method pathUrl operation =
                             , cmdParam = (paramType { requireToMsg = True }).lamderaProgramTest
                             }
                         )
-                        [ ( LamderaProgramTestCmd
+                        [ ( OpenApi.Config.LamderaProgramTestCmd
                           , \{ cmdArg, cmdParam } ->
                                 Elm.fn
                                     ( "config", Just cmdParam )
                                     (\config -> Gen.Effect.Http.call_.request (cmdArg config))
                                     |> Elm.declaration functionName
                           )
-                        , ( LamderaProgramTestCmdRisky
+                        , ( OpenApi.Config.LamderaProgramTestCmdRisky
                           , \{ cmdArg, cmdParam } ->
                                 Elm.fn
                                     ( "config", Just cmdParam )
                                     (\config -> Gen.Effect.Http.call_.riskyRequest (cmdArg config))
                                     |> Elm.declaration (functionName ++ "Risky")
                           )
-                        , ( LamderaProgramTestCmdRecord
+                        , ( OpenApi.Config.LamderaProgramTestCmdRecord
                           , \{ cmdArg, cmdParam } ->
                                 Elm.fn
                                     ( "config", Just cmdParam )
@@ -1212,7 +1188,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     )
                             }
                         )
-                        [ ( LamderaProgramTestTask
+                        [ ( OpenApi.Config.LamderaProgramTestTask
                           , \{ taskArg, taskAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1220,7 +1196,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     |> Elm.withType taskAnnotation
                                     |> Elm.declaration (functionName ++ "Task")
                           )
-                        , ( LamderaProgramTestTaskRisky
+                        , ( OpenApi.Config.LamderaProgramTestTaskRisky
                           , \{ taskArg, taskAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1228,7 +1204,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                     |> Elm.withType taskAnnotation
                                     |> Elm.declaration (functionName ++ "TaskRisky")
                           )
-                        , ( LamderaProgramTestTaskRecord
+                        , ( OpenApi.Config.LamderaProgramTestTaskRecord
                           , \{ taskArg, recordAnnotation } ->
                                 Elm.fn
                                     ( "config", Nothing )
@@ -1284,49 +1260,49 @@ toRequestFunctions server effectTypes method pathUrl operation =
         |> CliMonad.withPath (Common.UnsafeName pathUrl)
 
 
-effectTypeToPackage : EffectType -> Common.Package
+effectTypeToPackage : OpenApi.Config.EffectType -> Common.Package
 effectTypeToPackage effectType =
     case effectType of
-        ElmHttpCmd ->
+        OpenApi.Config.ElmHttpCmd ->
             Common.ElmHttp
 
-        ElmHttpCmdRisky ->
+        OpenApi.Config.ElmHttpCmdRisky ->
             Common.ElmHttp
 
-        ElmHttpCmdRecord ->
+        OpenApi.Config.ElmHttpCmdRecord ->
             Common.ElmHttp
 
-        ElmHttpTask ->
+        OpenApi.Config.ElmHttpTask ->
             Common.ElmHttp
 
-        ElmHttpTaskRisky ->
+        OpenApi.Config.ElmHttpTaskRisky ->
             Common.ElmHttp
 
-        ElmHttpTaskRecord ->
+        OpenApi.Config.ElmHttpTaskRecord ->
             Common.ElmHttp
 
-        DillonkearnsElmPagesTaskRecord ->
+        OpenApi.Config.DillonkearnsElmPagesTaskRecord ->
             Common.ElmHttp
 
-        DillonkearnsElmPagesTask ->
+        OpenApi.Config.DillonkearnsElmPagesTask ->
             Common.DillonkearnsElmPages
 
-        LamderaProgramTestCmd ->
+        OpenApi.Config.LamderaProgramTestCmd ->
             Common.LamderaProgramTest
 
-        LamderaProgramTestCmdRisky ->
+        OpenApi.Config.LamderaProgramTestCmdRisky ->
             Common.LamderaProgramTest
 
-        LamderaProgramTestCmdRecord ->
+        OpenApi.Config.LamderaProgramTestCmdRecord ->
             Common.LamderaProgramTest
 
-        LamderaProgramTestTask ->
+        OpenApi.Config.LamderaProgramTestTask ->
             Common.LamderaProgramTest
 
-        LamderaProgramTestTaskRisky ->
+        OpenApi.Config.LamderaProgramTestTaskRisky ->
             Common.LamderaProgramTest
 
-        LamderaProgramTestTaskRecord ->
+        OpenApi.Config.LamderaProgramTestTaskRecord ->
             Common.LamderaProgramTest
 
 
@@ -1399,7 +1375,7 @@ operationToHeaderParams operation =
         |> CliMonad.map (List.filterMap identity)
 
 
-replacedUrl : Server -> AuthorizationInfo -> String -> OpenApi.Operation.Operation -> CliMonad (Elm.Expression -> Elm.Expression)
+replacedUrl : OpenApi.Config.Server -> AuthorizationInfo -> String -> OpenApi.Operation.Operation -> CliMonad (Elm.Expression -> Elm.Expression)
 replacedUrl server authInfo pathUrl operation =
     let
         pathSegments : List String
@@ -1433,10 +1409,10 @@ replacedUrl server authInfo pathUrl operation =
                             resolvedServer : Result String Elm.Expression
                             resolvedServer =
                                 case server of
-                                    Single cliServer ->
+                                    OpenApi.Config.Single cliServer ->
                                         Err cliServer
 
-                                    Default ->
+                                    OpenApi.Config.Default ->
                                         case servers of
                                             [] ->
                                                 Err ""
@@ -1447,7 +1423,7 @@ replacedUrl server authInfo pathUrl operation =
                                             _ ->
                                                 Ok (Elm.get "server" config)
 
-                                    Multiple _ ->
+                                    OpenApi.Config.Multiple _ ->
                                         Ok (Elm.get "server" config)
                         in
                         if List.isEmpty pathSegments && List.isEmpty queryParams && List.isEmpty authArgs then
@@ -1922,7 +1898,7 @@ toConfigParamAnnotation :
     , errorTypeAnnotation : Elm.Annotation.Annotation
     , authorizationInfo : AuthorizationInfo
     , bodyParams : List ( Common.UnsafeName, Elm.Annotation.Annotation )
-    , server : Server
+    , server : OpenApi.Config.Server
     }
     -> CliMonad ({ requireToMsg : Bool } -> PerPackage Elm.Annotation.Annotation)
 toConfigParamAnnotation options =
@@ -1971,14 +1947,14 @@ toConfigParamAnnotation options =
         )
         (operationToUrlParams options.operation)
         (case options.server of
-            Multiple _ ->
+            OpenApi.Config.Multiple _ ->
                 [ ( Common.UnsafeName "server", Elm.Annotation.string ) ]
                     |> CliMonad.succeed
 
-            Single _ ->
+            OpenApi.Config.Single _ ->
                 CliMonad.succeed []
 
-            Default ->
+            OpenApi.Config.Default ->
                 OpenApi.servers
                     |> CliMonad.fromApiSpec
                     |> CliMonad.map

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -1,5 +1,6 @@
 module OpenApi.Generate exposing
-    ( ContentSchema(..)
+    ( Config
+    , ContentSchema(..)
     , EffectType(..)
     , Mime
     , Server(..)
@@ -112,13 +113,17 @@ type alias PerPackage a =
     }
 
 
-files :
+type alias Config =
     { namespace : List String
     , generateTodos : Bool
     , effectTypes : List EffectType
     , server : Server
     , formats : List CliMonad.Format
     }
+
+
+files :
+    Config
     -> OpenApi.OpenApi
     ->
         Result

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -78,8 +78,8 @@ suite =
                                 OpenApi.Generate.files
                                     { namespace = namespace
                                     , generateTodos = False
-                                    , effectTypes = [ OpenApi.Generate.ElmHttpCmd, OpenApi.Generate.ElmHttpTask ]
-                                    , server = OpenApi.Generate.Default
+                                    , effectTypes = [ OpenApi.Config.ElmHttpCmd, OpenApi.Config.ElmHttpTask ]
+                                    , server = OpenApi.Config.Default
                                     , formats = OpenApi.Config.defaultFormats
                                     }
                                     oas

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -1,7 +1,6 @@
 module Test.OpenApi.Generate exposing (suite)
 
 import Char
-import Cli
 import CliMonad
 import Elm
 import Expect
@@ -9,6 +8,7 @@ import FastSet
 import Fuzz
 import Json.Decode
 import OpenApi
+import OpenApi.Config
 import OpenApi.Generate
 import String.Extra
 import Test exposing (Test)
@@ -80,7 +80,7 @@ suite =
                                     , generateTodos = False
                                     , effectTypes = [ OpenApi.Generate.ElmHttpCmd, OpenApi.Generate.ElmHttpTask ]
                                     , server = OpenApi.Generate.Default
-                                    , formats = Cli.defaultFormats
+                                    , formats = OpenApi.Config.defaultFormats
                                     }
                                     oas
                         in


### PR DESCRIPTION
This creates a new `OpenApi.Config` module that will be the basis of the new configurable execution.

Draft while waiting for #168 