### PR TITLE
Fix elm-pages headers, deduplicate code

### DIFF
--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -708,9 +708,13 @@ toRequestFunctions server effectTypes method pathUrl operation =
                     CliMonad.succeed [ ( Common.UnsafeName "body", Gen.Bytes.annotation_.bytes ) ]
                         |> CliMonad.withRequiredPackage "elm/bytes"
 
-        headersFromList : (Elm.Expression -> Elm.Expression -> Elm.Expression) -> AuthorizationInfo -> Elm.Expression -> List ( Elm.Expression, Elm.Expression, Bool ) -> Elm.Expression
-        headersFromList f auth config headerParams =
+        headersFromList : (Elm.Expression -> Elm.Expression -> Elm.Expression) -> AuthorizationInfo -> Elm.Expression -> List (Elm.Expression -> ( Elm.Expression, Elm.Expression, Bool )) -> Elm.Expression
+        headersFromList f auth config headerFunctions =
             let
+                headerParams : List ( Elm.Expression, Elm.Expression, Bool )
+                headerParams =
+                    List.map (\toHeader -> toHeader config) headerFunctions
+
                 hasMaybes : Bool
                 hasMaybes =
                     List.any (\( _, _, isMaybe ) -> isMaybe) headerParams
@@ -857,9 +861,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                         [ ( "url", replaced config )
                                         , ( "method", Elm.string method )
                                         , ( "headers"
-                                          , toHeaderParams
-                                                |> List.map (\f -> f config)
-                                                |> headersFromList Gen.Http.call_.header auth config
+                                          , headersFromList Gen.Http.call_.header auth config toHeaderParams
                                           )
                                         , ( "expect", (expect <| toMsg config).core )
                                         , ( "body", (toBody config).core )
@@ -931,9 +933,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                         [ ( "url", replaced config )
                                         , ( "method", Elm.string method )
                                         , ( "headers"
-                                          , toHeaderParams
-                                                |> List.map (\f -> f config)
-                                                |> headersFromList Gen.Http.call_.header auth config
+                                          , headersFromList Gen.Http.call_.header auth config toHeaderParams
                                           )
                                         , ( "resolver", resolver.core )
                                         , ( "body", (toBody config).core )
@@ -1010,9 +1010,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                         [ ( "url", replaced config )
                                         , ( "method", Elm.string method )
                                         , ( "headers"
-                                          , toHeaderParams
-                                                |> List.map (\f -> f config)
-                                                |> headersFromList Gen.Http.call_.header auth config
+                                          , headersFromList Elm.tuple auth config toHeaderParams
                                           )
                                         , ( "body", (toBody config).elmPages )
                                         , ( "retries", Gen.Maybe.make_.nothing )
@@ -1083,9 +1081,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                         [ ( "url", replaced config )
                                         , ( "method", Elm.string method )
                                         , ( "headers"
-                                          , toHeaderParams
-                                                |> List.map (\f -> f config)
-                                                |> headersFromList Gen.Effect.Http.call_.header auth config
+                                          , headersFromList Gen.Effect.Http.call_.header auth config toHeaderParams
                                           )
                                         , ( "expect", (expect <| toMsg config).lamderaProgramTest )
                                         , ( "body", (toBody config).lamderaProgramTest )
@@ -1138,9 +1134,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                         [ ( "url", replaced config )
                                         , ( "method", Elm.string method )
                                         , ( "headers"
-                                          , toHeaderParams
-                                                |> List.map (\f -> f config)
-                                                |> headersFromList Gen.Effect.Http.call_.header auth config
+                                          , headersFromList Gen.Effect.Http.call_.header auth config toHeaderParams
                                           )
                                         , ( "resolver", resolver.lamderaProgramTest )
                                         , ( "body", (toBody config).lamderaProgramTest )


### PR DESCRIPTION
`elm-pages` uses `(String, String)` for headers