### PR TITLE
Support objects with additionalProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Support for params being passed in the header
 -   Support for `type : null`
 -   Support for `const : <value>`
+-   [Support for `additionalProperties` in objects](https://github.com/wolfadex/elm-open-api-cli/pull/184). [Adam DiCarlo](https://github.com/adamdicarlo0)
 
 ## [0.7.0] - 2024-09-23
 

--- a/elm.json
+++ b/elm.json
@@ -67,11 +67,8 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm/parser": "1.1.0",
             "elm-explorations/test": "2.2.0",
-            "lue-bird/elm-syntax-format": "1.1.7",
-            "miniBill/elm-unicode": "1.1.1",
-            "stil4m/elm-syntax": "7.3.8"
+            "miniBill/elm-unicode": "1.1.1"
         },
         "indirect": {}
     }

--- a/elm.json
+++ b/elm.json
@@ -67,8 +67,11 @@
     },
     "test-dependencies": {
         "direct": {
+            "elm/parser": "1.1.0",
             "elm-explorations/test": "2.2.0",
-            "miniBill/elm-unicode": "1.1.1"
+            "lue-bird/elm-syntax-format": "1.1.7",
+            "miniBill/elm-unicode": "1.1.1",
+            "stil4m/elm-syntax": "7.3.8"
         },
         "indirect": {}
     }

--- a/example/additional-properties.yaml
+++ b/example/additional-properties.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.1
+info:
+  title: "Additional Properties"
+  version: "1"
+components:
+  schemas:
+    Popularity:
+      type: object
+      properties:
+        tags:
+          type: object
+          properties:
+            declaredProperty:
+              type: string
+          required:
+            - declaredProperty
+          additionalProperties:
+            type: object
+            properties:
+              name:
+                type: string
+              isPopular:
+                type: boolean
+            required:
+              - name
+      required:
+        - tags
+    StringLists:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string
+
+paths:
+  "/api/popularity":
+    summary: Get Popularity
+    description:
+    get:
+      operationId: getPopularity
+      responses:
+        200:
+          $ref: "#/components/schemas/Popularity"
+  "/api/list":
+    summary: Get StringLists
+    description:
+    get:
+      operationId: getStringLists
+      responses:
+        200:
+          $ref: "#/components/schemas/StringLists"

--- a/example/additional-properties.yaml
+++ b/example/additional-properties.yaml
@@ -4,28 +4,35 @@ info:
   version: "1"
 components:
   schemas:
-    Popularity:
+    Taxonomy:
+      description: Taxonomy data
       type: object
       properties:
         tags:
+          description: Tag information
           type: object
           properties:
-            declaredProperty:
+            category:
+              description: Category of these tags
               type: string
           required:
             - declaredProperty
           additionalProperties:
+            description: Dictionary of tags, keyed by machine id
             type: object
             properties:
               name:
+                description: Name of the tag
                 type: string
               isPopular:
+                description: Whether the tag is popular
                 type: boolean
             required:
               - name
       required:
         - tags
     StringLists:
+      description: Lists of strings stored in arbitrary object keys
       type: object
       additionalProperties:
         type: array
@@ -35,8 +42,10 @@ components:
       type: object
       properties:
         a:
+          description: Something
           type: string
         b:
+          description: Something else
           type: string
       required:
         - b

--- a/example/additional-properties.yaml
+++ b/example/additional-properties.yaml
@@ -34,24 +34,10 @@ components:
     VagueExtras:
       type: object
       properties:
-        declaredProperty:
+        a:
           type: string
+        b:
+          type: string
+      required:
+        - b
       additionalProperties: true
-
-paths:
-  "/api/popularity":
-    summary: Get Popularity
-    description:
-    get:
-      operationId: getPopularity
-      responses:
-        200:
-          $ref: "#/components/schemas/Popularity"
-  "/api/list":
-    summary: Get StringLists
-    description:
-    get:
-      operationId: getStringLists
-      responses:
-        200:
-          $ref: "#/components/schemas/StringLists"

--- a/example/additional-properties.yaml
+++ b/example/additional-properties.yaml
@@ -31,6 +31,12 @@ components:
         type: array
         items:
           type: string
+    VagueExtras:
+      type: object
+      properties:
+        declaredProperty:
+          type: string
+      additionalProperties: true
 
 paths:
   "/api/popularity":

--- a/example/src/Example.elm
+++ b/example/src/Example.elm
@@ -2,9 +2,6 @@ module Example exposing (..)
 
 -- import BimcloudApi20232AlphaRelease
 
-import AdditionalProperties.Api
-import AdditionalProperties.Json
-import AdditionalProperties.Types
 import AirlineCodeLookupApi.Api
 import AirlineCodeLookupApi.Types
 import BasicRouter.Json
@@ -145,18 +142,6 @@ view _ =
 -- Assert the structure of generated types by declaring instances of them.
 
 
-{-| AdditionalProperties
--}
-additionalPropertiesPopularity : AdditionalProperties.Types.Popularity
-additionalPropertiesPopularity =
-    { tags = Dict.singleton "elm-open-api" { isPopular = Just True, name = "elm-open-api" } }
-
-
-additionalPropertiesStringList : AdditionalProperties.Types.StringLists
-additionalPropertiesStringList =
-    Dict.singleton "key" [ "" ]
-
-
 {-| BasicRouter
 -}
 basicRouterValuePropositionSummary : BasicRouter.Types.ValuePropositionSummary
@@ -185,28 +170,6 @@ recursiveAllofRefsGrandChild =
 
 
 -- Assert decoders and encoders return correct types with alias functions.
-
-
-{-| AdditionalProperties
--}
-decodeAdditionalPropertiesPopularity : Json.Decode.Decoder AdditionalProperties.Types.Popularity
-decodeAdditionalPropertiesPopularity =
-    AdditionalProperties.Json.decodePopularity
-
-
-encodeAdditionalPropertiesPopularity : Json.Encode.Encoder AdditionalProperties.Types.Popularity
-encodeAdditionalPropertiesPopularity =
-    AdditionalProperties.Json.encodePopularity
-
-
-decodeAdditionalPropertiesStringList : Json.Decode.Decoder AdditionalProperties.Types.StringList
-decodeAdditionalPropertiesStringList =
-    AdditionalProperties.Json.decodeStringList
-
-
-encodeAdditionalPropertiesStringList : Json.Encode.Encoder AdditionalProperties.Types.StringList
-encodeAdditionalPropertiesStringList =
-    AdditionalProperties.Json.encodeStringList
 
 
 {-| RecursiveAllofRefs

--- a/example/src/Example.elm
+++ b/example/src/Example.elm
@@ -2,6 +2,8 @@ module Example exposing (..)
 
 -- import BimcloudApi20232AlphaRelease
 
+import AdditionalProperties.Json
+import AdditionalProperties.Types
 import AirlineCodeLookupApi.Api
 import AirlineCodeLookupApi.Types
 import BasicRouter.Json
@@ -142,6 +144,20 @@ view _ =
 -- Assert the structure of generated types by declaring instances of them.
 
 
+{-| AdditionalProperties
+-}
+additionalPropertiesTaxonomy : AdditionalProperties.Types.Taxonomy
+additionalPropertiesTaxonomy =
+    { tags =
+        { additionalProperties =
+            Dict.fromList
+                [ ( "Mystery", { name = "Mystery", isPopular = Just True } )
+                ]
+        , category = Just "Genres"
+        }
+    }
+
+
 {-| BasicRouter
 -}
 basicRouterValuePropositionSummary : BasicRouter.Types.ValuePropositionSummary
@@ -166,19 +182,3 @@ recursiveAllofRefsGrandChild =
     , child = ""
     , grandChild = ""
     }
-
-
-
--- Assert decoders and encoders return correct types with alias functions.
-
-
-{-| RecursiveAllofRefs
--}
-decodeRecursiveAllofRefsChild : Json.Decode.Decoder RecursiveAllofRefs.Types.Child
-decodeRecursiveAllofRefsChild =
-    RecursiveAllofRefs.Json.decodeChild
-
-
-decodeRecursiveAllofRefsGrandChild : Json.Decode.Decoder RecursiveAllofRefs.Types.GrandChild
-decodeRecursiveAllofRefsGrandChild =
-    RecursiveAllofRefs.Json.decodeGrandChild

--- a/example/src/Example.elm
+++ b/example/src/Example.elm
@@ -2,6 +2,9 @@ module Example exposing (..)
 
 -- import BimcloudApi20232AlphaRelease
 
+import AdditionalProperties.Api
+import AdditionalProperties.Json
+import AdditionalProperties.Types
 import AirlineCodeLookupApi.Api
 import AirlineCodeLookupApi.Types
 import BasicRouter.Json
@@ -9,6 +12,7 @@ import BasicRouter.Types
 import Browser
 import DbFahrplanApi.Api
 import DbFahrplanApi.Types
+import Dict
 import GithubV3RestApi.Api
 import GithubV3RestApi.Types
 import Json.Decode
@@ -141,6 +145,18 @@ view _ =
 -- Assert the structure of generated types by declaring instances of them.
 
 
+{-| AdditionalProperties
+-}
+additionalPropertiesPopularity : AdditionalProperties.Types.Popularity
+additionalPropertiesPopularity =
+    { tags = Dict.singleton "elm-open-api" { isPopular = Just True, name = "elm-open-api" } }
+
+
+additionalPropertiesStringList : AdditionalProperties.Types.StringLists
+additionalPropertiesStringList =
+    Dict.singleton "key" [ "" ]
+
+
 {-| BasicRouter
 -}
 basicRouterValuePropositionSummary : BasicRouter.Types.ValuePropositionSummary
@@ -168,9 +184,33 @@ recursiveAllofRefsGrandChild =
 
 
 
--- Assert decoders return correct types with alias functions.
+-- Assert decoders and encoders return correct types with alias functions.
 
 
+{-| AdditionalProperties
+-}
+decodeAdditionalPropertiesPopularity : Json.Decode.Decoder AdditionalProperties.Types.Popularity
+decodeAdditionalPropertiesPopularity =
+    AdditionalProperties.Json.decodePopularity
+
+
+encodeAdditionalPropertiesPopularity : Json.Encode.Encoder AdditionalProperties.Types.Popularity
+encodeAdditionalPropertiesPopularity =
+    AdditionalProperties.Json.encodePopularity
+
+
+decodeAdditionalPropertiesStringList : Json.Decode.Decoder AdditionalProperties.Types.StringList
+decodeAdditionalPropertiesStringList =
+    AdditionalProperties.Json.decodeStringList
+
+
+encodeAdditionalPropertiesStringList : Json.Encode.Encoder AdditionalProperties.Types.StringList
+encodeAdditionalPropertiesStringList =
+    AdditionalProperties.Json.encodeStringList
+
+
+{-| RecursiveAllofRefs
+-}
 decodeRecursiveAllofRefsChild : Json.Decode.Decoder RecursiveAllofRefs.Types.Child
 decodeRecursiveAllofRefsChild =
     RecursiveAllofRefs.Json.decodeChild

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -318,7 +318,8 @@ type Type
         }
     | Null
     | List Type
-    | Dict Type
+      -- The type declared in additionalProperties, and a list of normal properties
+    | Dict Type Object
     | OneOf TypeName OneOfData
     | Enum (List UnsafeName)
     | Value

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -319,7 +319,7 @@ type Type
     | Null
     | List Type
       -- The type declared in additionalProperties, and a list of normal properties
-    | Dict Type Object
+    | Dict { type_ : Type, documentation : Maybe String } Object
     | OneOf TypeName OneOfData
     | Enum (List UnsafeName)
     | Value

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -318,6 +318,7 @@ type Type
         }
     | Null
     | List Type
+    | Dict Type
     | OneOf TypeName OneOfData
     | Enum (List UnsafeName)
     | Value

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -1258,59 +1258,56 @@ typeToDecoder qualify type_ =
                                             (Elm.apply Gen.Json.Decode.values_.andThen
                                                 [ Elm.fn (Elm.Arg.var "keyValuePairs")
                                                     (\keyValuePairs ->
-                                                        keyValuePairs
-                                                            |> Elm.Op.pipe
-                                                                (Elm.apply
-                                                                    Gen.List.values_.filterMap
-                                                                    [ Elm.fn (Elm.Arg.tuple (Elm.Arg.var "key") (Elm.Arg.var "jsonValue"))
-                                                                        (\( key, jsonValue ) ->
-                                                                            let
-                                                                                propertyNames : Elm.Expression
-                                                                                propertyNames =
-                                                                                    properties
-                                                                                        |> List.map (Tuple.first >> Common.unwrapUnsafe >> Elm.string)
-                                                                                        |> Elm.list
-                                                                            in
-                                                                            Elm.ifThen (Elm.apply Gen.List.values_.member [ key, propertyNames ])
-                                                                                Elm.nothing
-                                                                                (Elm.Let.letIn
-                                                                                    (\additionalPropertyDecoder ->
-                                                                                        Elm.Case.result
-                                                                                            (Elm.apply Gen.Json.Decode.values_.decodeValue
-                                                                                                [ additionalPropertyDecoder, jsonValue ]
-                                                                                            )
-                                                                                            { err =
-                                                                                                ( "decodeError"
-                                                                                                , \decodeError ->
-                                                                                                    let
-                                                                                                        decoderErrorAsString : Elm.Expression
-                                                                                                        decoderErrorAsString =
-                                                                                                            Elm.apply Gen.Json.Decode.values_.errorToString
-                                                                                                                [ decodeError ]
-                                                                                                    in
-                                                                                                    Elm.just
-                                                                                                        (Gen.Result.make_.err
-                                                                                                            (decoderErrorAsString
-                                                                                                                |> Elm.Op.append (Elm.string "': ")
-                                                                                                                |> Elm.Op.append key
-                                                                                                                |> Elm.Op.append (Elm.string "Field '")
-                                                                                                            )
-                                                                                                        )
-                                                                                                )
-                                                                                            , ok =
-                                                                                                ( "decodedValue"
-                                                                                                , \decodedValue ->
-                                                                                                    Elm.just
-                                                                                                        (Gen.Result.make_.ok (Elm.tuple key decodedValue))
-                                                                                                )
-                                                                                            }
+                                                        Gen.List.call_.filterMap
+                                                            (Elm.fn (Elm.Arg.tuple (Elm.Arg.var "key") (Elm.Arg.var "jsonValue"))
+                                                                (\( key, jsonValue ) ->
+                                                                    let
+                                                                        propertyNames : Elm.Expression
+                                                                        propertyNames =
+                                                                            properties
+                                                                                |> List.map (Tuple.first >> Common.unwrapUnsafe >> Elm.string)
+                                                                                |> Elm.list
+                                                                    in
+                                                                    Elm.ifThen (Elm.apply Gen.List.values_.member [ key, propertyNames ])
+                                                                        Elm.nothing
+                                                                        (Elm.Let.letIn
+                                                                            (\additionalPropertyDecoder ->
+                                                                                Elm.Case.result
+                                                                                    (Elm.apply Gen.Json.Decode.values_.decodeValue
+                                                                                        [ additionalPropertyDecoder, jsonValue ]
                                                                                     )
-                                                                                    |> Elm.Let.value "additionalPropertyDecoder" dictValueDecoder
-                                                                                    |> Elm.Let.toExpression
-                                                                                )
+                                                                                    { err =
+                                                                                        ( "decodeError"
+                                                                                        , \decodeError ->
+                                                                                            let
+                                                                                                decoderErrorAsString : Elm.Expression
+                                                                                                decoderErrorAsString =
+                                                                                                    Elm.apply Gen.Json.Decode.values_.errorToString
+                                                                                                        [ decodeError ]
+                                                                                            in
+                                                                                            Elm.just
+                                                                                                (Gen.Result.make_.err
+                                                                                                    (decoderErrorAsString
+                                                                                                        |> Elm.Op.append (Elm.string "': ")
+                                                                                                        |> Elm.Op.append key
+                                                                                                        |> Elm.Op.append (Elm.string "Field '")
+                                                                                                    )
+                                                                                                )
+                                                                                        )
+                                                                                    , ok =
+                                                                                        ( "decodedValue"
+                                                                                        , \decodedValue ->
+                                                                                            Elm.just
+                                                                                                (Gen.Result.make_.ok (Elm.tuple key decodedValue))
+                                                                                        )
+                                                                                    }
+                                                                            )
+                                                                            |> Elm.Let.value "additionalPropertyDecoder" dictValueDecoder
+                                                                            |> Elm.Let.toExpression
                                                                         )
-                                                                    ]
                                                                 )
+                                                            )
+                                                            keyValuePairs
                                                             |> Elm.Op.pipe
                                                                 (Elm.fn
                                                                     (Elm.Arg.var "resultPairs")

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -784,7 +784,10 @@ typeToAnnotationWithMaybe qualify type_ =
 
         Common.Dict additionalProperties fields ->
             let
-                additionalPropertiesField : ( Common.UnsafeName, { type_ : Common.Type, required : Bool, documentation : Maybe String } )
+                additionalPropertiesField :
+                    ( Common.UnsafeName
+                    , { type_ : Common.Type, required : Bool, documentation : Maybe String }
+                    )
                 additionalPropertiesField =
                     ( Common.UnsafeName "additionalProperties"
                     , { type_ = Common.Dict additionalProperties []

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -543,11 +543,8 @@ objectSchemaToType qualify subSchema =
                                                 first :: rest ->
                                                     " - additionalProperties: "
                                                         ++ first
-                                                        ++ "\n\n   Each value in the dict is a record of:"
-                                                        ++ (rest
-                                                                |> List.map (\line -> "    " ++ line)
-                                                                |> String.join "\n"
-                                                           )
+                                                        ++ "\n\n   Each value in the dict is a record of:    "
+                                                        ++ String.join "\n    " rest
                                         )
                                 ]
                                     |> joinIfNotEmpty "\n\n"

--- a/src/SchemaUtils.elm
+++ b/src/SchemaUtils.elm
@@ -661,7 +661,11 @@ typeToAnnotationWithNullable qualify type_ =
             CliMonad.map Elm.Annotation.list (typeToAnnotationWithNullable qualify t)
 
         Common.Dict dictValueType [] ->
-            CliMonad.map (Elm.Annotation.dict Elm.Annotation.string) (typeToAnnotationWithNullable qualify dictValueType)
+            -- We do not use `Elm.Annotation.dict` here because it will NOT
+            -- result in `import Dict` being generated in the module, due to
+            -- a bug in elm-codegen.
+            CliMonad.map (Gen.Dict.annotation_.dict Elm.Annotation.string)
+                (typeToAnnotationWithNullable qualify dictValueType)
 
         Common.Dict dictValueType fields ->
             let
@@ -744,7 +748,10 @@ typeToAnnotationWithMaybe qualify type_ =
             CliMonad.map Elm.Annotation.list (typeToAnnotationWithMaybe qualify t)
 
         Common.Dict dictValueType [] ->
-            CliMonad.map (Elm.Annotation.dict Elm.Annotation.string)
+            -- We do not use `Elm.Annotation.dict` here because it will NOT
+            -- result in `import Dict` being generated in the module, due to
+            -- a bug in elm-codegen.
+            CliMonad.map (Gen.Dict.annotation_.dict Elm.Annotation.string)
                 (typeToAnnotationWithMaybe qualify dictValueType)
 
         Common.Dict dictValueType fields ->

--- a/src/TestGenScript.elm
+++ b/src/TestGenScript.elm
@@ -16,6 +16,10 @@ import Pages.Script
 run : Pages.Script.Script
 run =
     let
+        additionalProperties : OpenApi.Config.Input
+        additionalProperties =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/additional-properties.yaml")
+
         recursiveAllofRefs : OpenApi.Config.Input
         recursiveAllofRefs =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/recursive-allof-refs.yaml")
@@ -69,6 +73,7 @@ run =
         config =
             OpenApi.Config.init "./generated"
                 |> OpenApi.Config.withAutoConvertSwagger True
+                |> OpenApi.Config.withInput additionalProperties
                 |> OpenApi.Config.withInput recursiveAllofRefs
                 |> OpenApi.Config.withInput singleEnum
                 |> OpenApi.Config.withInput patreon

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -92,7 +92,11 @@ expectDeclarationBody type_ module_ expectedBody =
         |> Maybe.map .body
         |> Maybe.map
             (\actualBody ->
-                Expect.equal actualBody (unindent expectedBody)
+                let
+                    _ =
+                        Debug.log actualBody "<- actualBody\n"
+                in
+                Expect.equal (String.trim actualBody) (unindent expectedBody)
             )
         |> Maybe.withDefault
             (Expect.fail
@@ -302,14 +306,16 @@ suite =
                                         """
                                             decodeVagueExtras : Json.Decode.Decoder AdditionalProperties.Types.VagueExtras
                                             decodeVagueExtras =
-                                                XXX
-                                        """
-                                    , expectDeclarationBody "decodeVagueExtras"
-                                        jsonFile
-                                        """
-                                            decodeVagueExtras : Json.Decode.Decoder AdditionalProperties.Types.VagueExtras
-                                            decodeVagueExtras =
-                                                XXX
+                                                Json.Decode.succeed
+                                                    (\\declaredProperty additionalProperties ->
+                                                        { declaredProperty = declaredProperty
+                                                        , additionalProperties = additionalProperties
+                                                        }
+                                                    ) |> OpenApi.Common.jsonDecodeAndMap
+                                                        (OpenApi.Common.decodeOptionalField
+                                                                "declaredProperty"
+                                                                Json.Decode.string
+                                                        )
                                         """
                                     ]
 

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -2,7 +2,6 @@ module Test.OpenApi.Generate exposing (suite)
 
 import Char
 import CliMonad
-import Dict
 import Elm
 import Elm.Parser
 import Elm.Syntax.Node
@@ -13,7 +12,6 @@ import FastDict
 import FastSet
 import Fuzz
 import Json.Decode
-import Json.Encode
 import List.Extra
 import OpenApi
 import OpenApi.Config
@@ -129,6 +127,12 @@ expectDeclarationBody type_ module_ expectedBody =
         |> Maybe.map
             (\actualBody ->
                 Expect.equal actualBody (unindent expectedBody)
+                    |> Expect.onFail
+                        ("Actual value:\n"
+                            ++ actualBody
+                            ++ "\n\nExpected value:\n"
+                            ++ unindent expectedBody
+                        )
             )
         |> Maybe.withDefault
             (Expect.fail
@@ -363,10 +367,10 @@ encodeVagueExtras rec =
             )
         )
                         """
-                    , expectDeclarationBody "Popularity"
+                    , expectDeclarationBody "Taxonomy"
                         typesFile
                         """
-                                type alias Popularity =
+                                type alias Taxonomy =
                                     { tags :
                                         { additionalProperties :
                                             Dict.Dict String { isPopular : Maybe Bool, name : String }
@@ -374,8 +378,8 @@ encodeVagueExtras rec =
                                         }
                                     }
                         """
-                    , expectDeclarationBody "decodePopularity" jsonFile expectedDecodePopularity
-                    , expectDeclarationBody "encodePopularity" jsonFile expectedEncodePopularity
+                    , expectDeclarationBody "decodeTaxonomy" jsonFile expectedDecodeTaxonomy
+                    , expectDeclarationBody "encodeTaxonomy" jsonFile expectedEncodeTaxonomy
                     ]
         ]
 
@@ -391,14 +395,16 @@ additionalPropertiesOasString =
   },
   "components": {
     "schemas": {
-      "Popularity": {
+      "Taxonomy": {
         "type": "object",
         "required": [
           "tags"
         ],
         "properties": {
           "tags": {
+            "type": "object",
             "additionalProperties": {
+              "type": "object",
               "properties": {
                 "isPopular": {
                   "type": "boolean"
@@ -409,8 +415,7 @@ additionalPropertiesOasString =
               },
               "required": [
                 "name"
-              ],
-              "type": "object"
+              ]
             },
             "properties": {
               "declaredProperty": {
@@ -419,8 +424,7 @@ additionalPropertiesOasString =
             },
             "required": [
               "declaredProperty"
-            ],
-            "type": "object"
+            ]
           }
         }
       },
@@ -451,11 +455,11 @@ additionalPropertiesOasString =
 }"""
 
 
-expectedDecodePopularity : String
-expectedDecodePopularity =
+expectedDecodeTaxonomy : String
+expectedDecodeTaxonomy =
     """
-decodePopularity : Json.Decode.Decoder AdditionalProperties.Types.Popularity
-decodePopularity =
+decodeTaxonomy : Json.Decode.Decoder AdditionalProperties.Types.Taxonomy
+decodeTaxonomy =
     Json.Decode.succeed
         (\\tags -> { tags = tags })
         |> OpenApi.Common.jsonDecodeAndMap
@@ -582,11 +586,11 @@ decodePopularity =
                                 """
 
 
-expectedEncodePopularity : String
-expectedEncodePopularity =
+expectedEncodeTaxonomy : String
+expectedEncodeTaxonomy =
     """
-encodePopularity : AdditionalProperties.Types.Popularity -> Json.Encode.Value
-encodePopularity rec =
+encodeTaxonomy : AdditionalProperties.Types.Taxonomy -> Json.Encode.Value
+encodeTaxonomy rec =
     Json.Encode.object
         [ ( "tags"
           , Json.Encode.object

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -19,7 +19,7 @@ import Utils
 moduleNames : List { a | moduleName : List String } -> String
 moduleNames modules =
     modules
-        |> List.map (.moduleName >> String.join ".")
+        |> List.map (\{ moduleName } -> String.join "." moduleName)
         |> String.Extra.toSentenceOxford
 
 

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -136,10 +136,7 @@ expectDeclarationBody type_ module_ expectedBody =
             )
 
 
-{-|
-
-    Wraps Test.test to make it easy to test files produced by a given OAS.
-
+{-| Wraps Test.test to make it easy to test files produced by a given OAS.
 -}
 testOas : String -> String -> ({ helperFile : GeneratedModule, jsonFile : GeneratedModule, typesFile : GeneratedModule } -> Expect.Expectation) -> Test.Test
 testOas name oasSpec test =
@@ -477,69 +474,68 @@ decodePopularity =
                             "declaredProperty"
                             Json.Decode.string
                         )
-                    |> (OpenApi.Common.jsonDecodeAndMap
-                            (Json.Decode.keyValuePairs
-                                Json.Decode.value
-                            )
+                    |> OpenApi.Common.jsonDecodeAndMap
+                        (Json.Decode.keyValuePairs
+                            Json.Decode.value
                             |> Json.Decode.andThen
                                 (\\keyValuePairs ->
-                                    keyValuePairs
-                                        |> List.filterMap
-                                            (\\( key, jsonValue ) ->
-                                                if
-                                                    List.member
-                                                        key
-                                                        [ "declaredProperty"
-                                                        ]
-                                                then
-                                                    Nothing
+                                    List.filterMap
+                                        (\\( key, jsonValue ) ->
+                                            if
+                                                List.member
+                                                    key
+                                                    [ "declaredProperty"
+                                                    ]
+                                            then
+                                                Nothing
 
-                                                else
-                                                    let
-                                                        additionalPropertyDecoder =
-                                                            Json.Decode.succeed
-                                                                (\\isPopular name ->
-                                                                    { isPopular =
-                                                                        isPopular
-                                                                    , name =
-                                                                        name
-                                                                    }
+                                            else
+                                                let
+                                                    additionalPropertyDecoder =
+                                                        Json.Decode.succeed
+                                                            (\\isPopular name ->
+                                                                { isPopular =
+                                                                    isPopular
+                                                                , name =
+                                                                    name
+                                                                }
+                                                            )
+                                                            |> OpenApi.Common.jsonDecodeAndMap
+                                                                (OpenApi.Common.decodeOptionalField
+                                                                    "isPopular"
+                                                                    Json.Decode.bool
                                                                 )
-                                                                |> OpenApi.Common.jsonDecodeAndMap
-                                                                    (OpenApi.Common.decodeOptionalField
-                                                                        "isPopular"
-                                                                        Json.Decode.bool
-                                                                    )
-                                                                |> OpenApi.Common.jsonDecodeAndMap
-                                                                    (Json.Decode.field
-                                                                        "name"
-                                                                        Json.Decode.string
-                                                                    )
-                                                    in
-                                                    case
-                                                        Json.Decode.decodeValue
-                                                            additionalPropertyDecoder
-                                                            jsonValue
-                                                    of
-                                                        Ok decodedValue ->
-                                                            Just
-                                                                (Result.Ok
-                                                                    ( key
-                                                                    , decodedValue
-                                                                    )
+                                                            |> OpenApi.Common.jsonDecodeAndMap
+                                                                (Json.Decode.field
+                                                                    "name"
+                                                                    Json.Decode.string
                                                                 )
+                                                in
+                                                case
+                                                    Json.Decode.decodeValue
+                                                        additionalPropertyDecoder
+                                                        jsonValue
+                                                of
+                                                    Ok decodedValue ->
+                                                        Just
+                                                            (Result.Ok
+                                                                ( key
+                                                                , decodedValue
+                                                                )
+                                                            )
 
-                                                        Err decodeError ->
-                                                            Just
-                                                                (Result.Err
-                                                                    ("Field '"
-                                                                        ++ key
-                                                                        ++ "': "
-                                                                        ++ Json.Decode.errorToString
-                                                                            decodeError
-                                                                    )
+                                                    Err decodeError ->
+                                                        Just
+                                                            (Result.Err
+                                                                ("Field '"
+                                                                    ++ key
+                                                                    ++ "': "
+                                                                    ++ Json.Decode.errorToString
+                                                                        decodeError
                                                                 )
-                                            )
+                                                            )
+                                        )
+                                        keyValuePairs
                                         |> (\\resultPairs ->
                                                 let
                                                     fieldErrors =
@@ -580,7 +576,7 @@ decodePopularity =
                                                         |> Json.Decode.fail
                                            )
                                 )
-                       )
+                        )
                 )
             )
                                 """

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -2,7 +2,9 @@ module Test.OpenApi.Generate exposing (suite)
 
 import Char
 import CliMonad
+import Dict
 import Elm
+import Elm.ToString
 import Expect
 import FastDict
 import FastSet
@@ -11,9 +13,70 @@ import Json.Decode
 import OpenApi
 import OpenApi.Config
 import OpenApi.Generate
+import Result.Extra
 import String.Extra
 import Test exposing (Test)
 import Utils
+
+
+type alias GeneratedModule =
+    { moduleName : List String
+    , declarations : FastDict.Dict String { group : String, declaration : Elm.Declaration }
+    }
+
+
+moduleNames : List { a | moduleName : List String } -> String
+moduleNames modules =
+    modules
+        |> List.map (.moduleName >> String.join ".")
+        |> String.Extra.toSentenceOxford
+
+
+expectModuleName : { a | moduleName : List String } -> List String -> Expect.Expectation
+expectModuleName file expectedPath =
+    Expect.equal file.moduleName expectedPath
+        |> Expect.onFail ("Expected to generate a file with the module name " ++ String.join "." expectedPath ++ " but I found " ++ moduleNames [ file ])
+
+
+composeExpectations : List Expect.Expectation -> Expect.Expectation
+composeExpectations expectations =
+    Expect.all
+        (List.map (\x -> always x) expectations)
+        ()
+
+
+{-| Remove all indentation and newlines from a stringified Elm declaration
+-}
+toOneLine : String -> String
+toOneLine declaration =
+    declaration
+        |> String.split "\n"
+        |> List.map String.trim
+        |> String.join " "
+        |> String.trim
+
+
+{-| Expect the `type_` from `module_` to be stringified as `expectedBody`
+
+expectedBody may have mutiple lines, with arbitrary indentation (leading and
+trailing spaces and newlines will not be considered in the comparison).
+
+-}
+expectType : GeneratedModule -> String -> String -> Expect.Expectation
+expectType module_ type_ expectedBody =
+    module_.declarations
+        |> FastDict.get type_
+        |> Maybe.map (.declaration >> Elm.ToString.declaration)
+        |> Maybe.andThen List.head
+        |> Maybe.map .body
+        |> Maybe.map
+            (\actualBody ->
+                Expect.equal (toOneLine actualBody) (toOneLine expectedBody)
+            )
+        |> Maybe.withDefault
+            (Expect.fail
+                ("expectType with " ++ type_ ++ " generated no declarations")
+            )
 
 
 suite : Test
@@ -92,47 +155,36 @@ suite =
 
                             Ok ( files, _ ) ->
                                 case files of
-                                    [] ->
-                                        Expect.fail "Expected to generate 3 files but found none"
-
-                                    [ file ] ->
-                                        Expect.fail ("Expected to generate 3 files but found 1: " ++ String.join "." file.moduleName)
-
-                                    [ file1, file2 ] ->
-                                        Expect.fail ("Expected to generate 3 files but found 2: " ++ String.join "." file1.moduleName ++ ", " ++ String.join "." file2.moduleName)
-
                                     [ jsonFile, apiFile, helperFile ] ->
                                         let
                                             jsonPath : List String
                                             jsonPath =
                                                 namespace ++ [ "Json" ]
+
+                                            apiPath : List String
+                                            apiPath =
+                                                namespace ++ [ "Api" ]
+
+                                            helperPath : List String
+                                            helperPath =
+                                                namespace ++ [ "OpenApi" ]
                                         in
-                                        if jsonFile.moduleName /= jsonPath then
-                                            Expect.fail ("Expected to generate a file with the module name " ++ String.join "." jsonPath ++ " but I found " ++ String.join "." jsonFile.moduleName)
+                                        composeExpectations
+                                            [ expectModuleName jsonFile jsonPath
+                                            , expectModuleName apiFile apiPath
+                                            , expectModuleName helperFile helperPath
+                                            ]
 
-                                        else
-                                            let
-                                                apiPath : List String
-                                                apiPath =
-                                                    namespace ++ [ "Api" ]
-                                            in
-                                            if apiFile.moduleName /= apiPath then
-                                                Expect.fail ("Expected to generate a file with the module name " ++ String.join "." apiPath ++ " but I found " ++ String.join "." apiFile.moduleName)
+                                    [] ->
+                                        Expect.fail "Expected to generate 3 files but found none"
 
-                                            else
-                                                let
-                                                    helperPath : List String
-                                                    helperPath =
-                                                        namespace ++ [ "OpenApi" ]
-                                                in
-                                                if helperFile.moduleName /= helperPath then
-                                                    Expect.fail ("Expected to generate a file with the module name " ++ String.join "." helperPath ++ " but I found " ++ String.join "." helperFile.moduleName)
-
-                                                else
-                                                    Expect.pass
-
-                                    _ :: _ :: _ :: extraFiles ->
-                                        Expect.fail ("Expected to generate 3 files but found extra: " ++ String.Extra.toSentenceOxford (List.map (\{ moduleName } -> String.join "." moduleName) extraFiles))
+                                    _ ->
+                                        Expect.fail
+                                            ("Expected to generate 3 files but found "
+                                                ++ (List.length files |> String.fromInt)
+                                                ++ ": "
+                                                ++ moduleNames files
+                                            )
 
         -- Known bug: https://github.com/wolfadex/elm-open-api-cli/issues/48
         , Test.test "The OAS title: service API (params in:body)" <|
@@ -143,4 +195,313 @@ suite =
                         Utils.sanitizeModuleName "service API (params in:body)"
                 in
                 Expect.equal moduleName (Just "ServiceApiParamsInBody")
+        , Test.test "Additional Properties" <|
+            \() ->
+                let
+                    namespace : List String
+                    namespace =
+                        Utils.sanitizeModuleName "Additional Properties"
+                            |> Maybe.withDefault "Earl"
+                            |> List.singleton
+
+                    genFiles : Result CliMonad.Message ( List { moduleName : List String, declarations : FastDict.Dict String { group : String, declaration : Elm.Declaration } }, { warnings : List CliMonad.Message, requiredPackages : FastSet.Set String } )
+                    genFiles =
+                        Json.Decode.decodeString OpenApi.decode additionalPropertiesOasString
+                            |> Result.mapError (\_ -> { message = "Failed to decode additionalProperties schema", path = [] })
+                            |> Result.andThen
+                                (\oas ->
+                                    OpenApi.Generate.files
+                                        { namespace = namespace
+                                        , generateTodos = False
+                                        , effectTypes = [ OpenApi.Config.ElmHttpTask ]
+                                        , server = OpenApi.Config.Default
+                                        , formats = OpenApi.Config.defaultFormats
+                                        }
+                                        oas
+                                )
+                in
+                case genFiles of
+                    Err { message } ->
+                        Expect.fail message
+
+                    Ok ( files, _ ) ->
+                        case files of
+                            [ apiFile, jsonFile, typesFile, helperFile ] ->
+                                composeExpectations
+                                    [ expectModuleName apiFile (namespace ++ [ "Api" ])
+                                    , expectModuleName typesFile (namespace ++ [ "Types" ])
+                                    , expectModuleName jsonFile (namespace ++ [ "Json" ])
+                                    , expectModuleName helperFile [ "OpenApi", "Common" ]
+                                    , expectType typesFile
+                                        "Popularity"
+                                        """
+                                            type alias Popularity =
+                                                { tags :
+                                                    { additionalProperties : Maybe (Dict.Dict String { isPopular : Maybe Bool, name : String })
+                                                    , declaredProperty : String
+                                                    }
+                                                }
+                                        """
+                                    , expectType typesFile
+                                        "StringLists"
+                                        "type alias StringLists = Dict.Dict String (List String)"
+                                    , expectType typesFile
+                                        "VagueExtras"
+                                        """
+                                            type alias VagueExtras =
+                                                { additionalProperties : Maybe (Dict.Dict String Json.Encode.Value)
+                                                , declaredProperty : Maybe String
+                                                }
+                                        """
+                                    ]
+
+                            [] ->
+                                Expect.fail "Expected to generate 4 files but found none"
+
+                            _ ->
+                                Expect.fail
+                                    ("Expected to generate 4 files but found "
+                                        ++ (List.length files |> String.fromInt)
+                                        ++ ": "
+                                        ++ moduleNames files
+                                    )
+        , Test.test "Decoder" <|
+            \() ->
+                let
+                    json : String
+                    json =
+                        """
+                        {
+                          "tags": {
+                            "declaredProperty": "declared",
+                            "foo": { "isPopular": true, "name": "foo" },
+                            "bar": { "name": "bar" }
+                          }
+                        }"""
+
+                    jsonDecodeAndMap :
+                        Json.Decode.Decoder a
+                        -> Json.Decode.Decoder (a -> value)
+                        -> Json.Decode.Decoder value
+                    jsonDecodeAndMap =
+                        Json.Decode.map2 (|>)
+
+                    decodeOptionalField : String -> Json.Decode.Decoder t -> Json.Decode.Decoder (Maybe t)
+                    decodeOptionalField key fieldDecoder =
+                        Json.Decode.andThen
+                            (\andThenUnpack ->
+                                if andThenUnpack then
+                                    Json.Decode.field
+                                        key
+                                        (Json.Decode.oneOf
+                                            [ Json.Decode.map Just fieldDecoder
+                                            , Json.Decode.null Nothing
+                                            ]
+                                        )
+
+                                else
+                                    Json.Decode.succeed Nothing
+                            )
+                            (Json.Decode.oneOf
+                                [ Json.Decode.map
+                                    (\_ -> True)
+                                    (Json.Decode.field key Json.Decode.value)
+                                , Json.Decode.succeed False
+                                ]
+                            )
+
+                    decoder : Json.Decode.Decoder { tags : { additionalProperties : Dict.Dict String { isPopular : Maybe Bool, name : String }, declaredProperty : String } }
+                    decoder =
+                        Json.Decode.succeed
+                            (\tags -> { tags = tags })
+                            |> jsonDecodeAndMap
+                                (Json.Decode.field "tags"
+                                    (Json.Decode.succeed
+                                        (\additionalProperties declaredProperty ->
+                                            { additionalProperties =
+                                                additionalProperties
+                                            , declaredProperty =
+                                                declaredProperty
+                                            }
+                                        )
+                                        |> jsonDecodeAndMap
+                                            -- Decode the additionalProperties first.
+                                            (Json.Decode.keyValuePairs Json.Decode.value
+                                                |> Json.Decode.andThen
+                                                    (\keyValuePairs ->
+                                                        keyValuePairs
+                                                            |> List.filterMap
+                                                                (\( k, v ) ->
+                                                                    -- Skip keys of declared properties
+                                                                    if List.member k [ "declaredProperty" ] then
+                                                                        Nothing
+
+                                                                    else
+                                                                        let
+                                                                            -- Decodes each additionalProperties value
+                                                                            addPropValueDecoder : Json.Decode.Decoder { isPopular : Maybe Bool, name : String }
+                                                                            addPropValueDecoder =
+                                                                                Json.Decode.succeed
+                                                                                    (\isPopular name ->
+                                                                                        { isPopular = isPopular
+                                                                                        , name = name
+                                                                                        }
+                                                                                    )
+                                                                                    |> jsonDecodeAndMap (decodeOptionalField "isPopular" Json.Decode.bool)
+                                                                                    |> jsonDecodeAndMap (Json.Decode.field "name" Json.Decode.string)
+                                                                        in
+                                                                        case Json.Decode.decodeValue addPropValueDecoder v of
+                                                                            Err decodeError ->
+                                                                                Just (Err ("Field '" ++ k ++ "': " ++ Json.Decode.errorToString decodeError))
+
+                                                                            Ok value ->
+                                                                                Just (Ok ( k, value ))
+                                                                )
+                                                            |> (\resultPairs ->
+                                                                    let
+                                                                        fieldErrors : List String
+                                                                        fieldErrors =
+                                                                            resultPairs
+                                                                                |> List.filterMap
+                                                                                    (\res ->
+                                                                                        case res of
+                                                                                            Ok _ ->
+                                                                                                Nothing
+
+                                                                                            Err error ->
+                                                                                                Just error
+                                                                                    )
+                                                                    in
+                                                                    if List.isEmpty fieldErrors then
+                                                                        resultPairs
+                                                                            |> List.filterMap Result.toMaybe
+                                                                            |> Dict.fromList
+                                                                            |> Json.Decode.succeed
+
+                                                                    else
+                                                                        [ "Encountered errors while decoding additionalProperties:\n- "
+                                                                        , fieldErrors |> String.join "\n\n- "
+                                                                        , "\n"
+                                                                        ]
+                                                                            |> String.concat
+                                                                            |> Json.Decode.fail
+                                                               )
+                                                    )
+                                            )
+                                        -- Decode all the declared properties now
+                                        |> jsonDecodeAndMap
+                                            (Json.Decode.field "declaredProperty" Json.Decode.string)
+                                    )
+                                )
+                in
+                case Json.Decode.decodeString decoder json of
+                    Err err ->
+                        err
+                            |> Json.Decode.errorToString
+                            |> Expect.fail
+
+                    Ok stuff ->
+                        Expect.equal stuff
+                            { tags =
+                                { additionalProperties =
+                                    Dict.fromList
+                                        [ ( "bar", { isPopular = Nothing, name = "bar" } )
+                                        , ( "foo", { isPopular = Just True, name = "foo" } )
+                                        ]
+                                , declaredProperty = "declared"
+                                }
+                            }
         ]
+
+
+additionalPropertiesOasString : String
+additionalPropertiesOasString =
+    """
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Additional Properties",
+    "version": "1"
+  },
+  "components": {
+    "schemas": {
+      "Popularity": {
+        "properties": {
+          "tags": {
+            "additionalProperties": {
+              "properties": {
+                "isPopular": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "properties": {
+              "declaredProperty": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "declaredProperty"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "tags"
+        ],
+        "type": "object"
+      },
+      "StringLists": {
+        "additionalProperties": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": "object"
+      },
+      "VagueExtras": {
+        "additionalProperties": true,
+        "properties": {
+          "declaredProperty": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "paths": {
+    "/api/list": {
+      "description": null,
+      "get": {
+        "operationId": "getStringLists",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/StringLists"
+          }
+        }
+      },
+      "summary": "Get StringLists"
+    },
+    "/api/popularity": {
+      "description": null,
+      "get": {
+        "operationId": "getPopularity",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/Popularity"
+          }
+        }
+      },
+      "summary": "Get Popularity"
+    }
+  }
+}"""

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -3,29 +3,17 @@ module Test.OpenApi.Generate exposing (suite)
 import Char
 import CliMonad
 import Elm
-import Elm.Parser
-import Elm.Syntax.Node
-import Elm.ToString
-import ElmSyntaxPrint
 import Expect
 import FastDict
 import FastSet
 import Fuzz
 import Json.Decode
-import List.Extra
 import OpenApi
 import OpenApi.Config
 import OpenApi.Generate
-import Parser
 import String.Extra
 import Test exposing (Test)
 import Utils
-
-
-type alias GeneratedModule =
-    { moduleName : List String
-    , declarations : FastDict.Dict String { group : String, declaration : Elm.Declaration }
-    }
 
 
 moduleNames : List { a | moduleName : List String } -> String
@@ -38,7 +26,12 @@ moduleNames modules =
 expectModuleName : { a | moduleName : List String } -> List String -> Expect.Expectation
 expectModuleName file expectedPath =
     Expect.equal file.moduleName expectedPath
-        |> Expect.onFail ("Expected to generate a file with the module name " ++ String.join "." expectedPath ++ " but I found " ++ moduleNames [ file ])
+        |> Expect.onFail
+            ("Expected to generate a file with the module name "
+                ++ String.join "." expectedPath
+                ++ " but I found "
+                ++ moduleNames [ file ]
+            )
 
 
 composeExpectations : List Expect.Expectation -> Expect.Expectation
@@ -46,151 +39,6 @@ composeExpectations expectations =
     Expect.all
         (List.map (\x -> always x) expectations)
         ()
-
-
-getIndentation : String -> Int
-getIndentation text =
-    text
-        |> String.lines
-        |> List.Extra.dropWhile String.isEmpty
-        |> List.head
-        |> Maybe.map (\firstLine -> String.length firstLine - String.length (String.trimLeft firstLine))
-        |> Maybe.withDefault 0
-
-
-{-| Remove all indentation and newlines from a stringified Elm declaration
--}
-unindent : String -> String
-unindent declaration =
-    let
-        indentation : Int
-        indentation =
-            getIndentation declaration
-    in
-    declaration
-        |> String.lines
-        |> List.Extra.dropWhile String.isEmpty
-        |> List.map (\line -> String.dropLeft indentation line)
-        |> String.join "\n"
-        |> String.trim
-
-
-getDeclaration : String -> GeneratedModule -> Maybe { imports : String, docs : String, signature : String, body : String }
-getDeclaration name module_ =
-    module_.declarations
-        |> FastDict.get name
-        |> Maybe.map (.declaration >> Elm.ToString.declaration)
-        |> Maybe.andThen List.head
-        -- Elm.ToString generates extremely over-indented code, so use the
-        -- elm-syntax-format package to re-indent the code for human
-        -- readability in "snapshot"-style tests.
-        |> Maybe.map
-            (\declaration ->
-                let
-                    srcFile : String
-                    srcFile =
-                        "module Foo exposing (..)\n\n\n" ++ declaration.body
-                in
-                case Elm.Parser.parseToFile srcFile of
-                    Err errors ->
-                        { declaration | body = Parser.deadEndsToString errors }
-
-                    Ok file ->
-                        List.head file.declarations
-                            |> Maybe.map
-                                (\decl ->
-                                    { declaration
-                                        | body =
-                                            ElmSyntaxPrint.declaration
-                                                { portDocumentationComment = Nothing, comments = [] }
-                                                (Elm.Syntax.Node.value decl)
-                                                { indent = 0 }
-                                    }
-                                )
-                            |> Maybe.withDefault
-                                { declaration
-                                    | body = "Bad parse result in test for " ++ name ++ ": no declarations"
-                                }
-            )
-
-
-{-| Expect the `type_` from `module_` to be stringified as `expectedBody`
-
-expectedBody may have mutiple lines, with arbitrary indentation (leading and
-trailing spaces and newlines will not be considered in the comparison).
-
--}
-expectDeclarationBody : String -> GeneratedModule -> String -> Expect.Expectation
-expectDeclarationBody type_ module_ expectedBody =
-    getDeclaration type_ module_
-        |> Maybe.map .body
-        |> Maybe.map
-            (\actualBody ->
-                Expect.equal actualBody (unindent expectedBody)
-                    |> Expect.onFail
-                        ("Actual value:\n"
-                            ++ actualBody
-                            ++ "\n\nExpected value:\n"
-                            ++ unindent expectedBody
-                        )
-            )
-        |> Maybe.withDefault
-            (Expect.fail
-                ("expectType with " ++ type_ ++ " generated no declarations")
-            )
-
-
-{-| Wraps Test.test to make it easy to test files produced by a given OAS.
--}
-testOas : String -> String -> ({ helperFile : GeneratedModule, jsonFile : GeneratedModule, typesFile : GeneratedModule } -> Expect.Expectation) -> Test.Test
-testOas name oasSpec test =
-    let
-        namespace : List String
-        namespace =
-            Utils.sanitizeModuleName name
-                |> Maybe.withDefault "BadOasNamespace"
-                |> List.singleton
-    in
-    Test.test (name ++ " OAS") <|
-        \() ->
-            Json.Decode.decodeString OpenApi.decode oasSpec
-                |> Result.mapError (\err -> "Failed to decode " ++ name ++ " OAS. Details: " ++ Json.Decode.errorToString err)
-                |> Result.andThen
-                    (\oas ->
-                        OpenApi.Generate.files
-                            { namespace = namespace
-                            , generateTodos = False
-                            , effectTypes = [ OpenApi.Config.ElmHttpTask ]
-                            , server = OpenApi.Config.Default
-                            , formats = OpenApi.Config.defaultFormats
-                            }
-                            oas
-                            |> Result.mapError (\err -> "Failed to generate " ++ name ++ " OAS. Details: " ++ err.message ++ "\nPath: " ++ String.join "." err.path)
-                    )
-                |> (\result ->
-                        case result of
-                            Ok ( files, _ ) ->
-                                case files of
-                                    [ jsonFile, typesFile, helperFile ] ->
-                                        test { jsonFile = jsonFile, typesFile = typesFile, helperFile = helperFile }
-
-                                    [] ->
-                                        Expect.fail (name ++ ": Expected to generate 3 files but found none")
-
-                                    _ ->
-                                        Expect.fail
-                                            ([ name
-                                             , ": Expected to generate 3 files but found "
-                                             , List.length files |> String.fromInt
-                                             , ": "
-                                             , moduleNames files
-                                             ]
-                                                |> String.concat
-                                            )
-
-                            Err err ->
-                                Expect.fail err
-                   )
 
 
 suite : Test
@@ -255,8 +103,13 @@ suite =
                             genFiles :
                                 Result
                                     CliMonad.Message
-                                    ( List { moduleName : List String, declarations : FastDict.Dict String { group : String, declaration : Elm.Declaration } }
-                                    , { warnings : List CliMonad.Message, requiredPackages : FastSet.Set String }
+                                    ( List
+                                        { moduleName : List String
+                                        , declarations : FastDict.Dict String { group : String, declaration : Elm.Declaration }
+                                        }
+                                    , { warnings : List CliMonad.Message
+                                      , requiredPackages : FastSet.Set String
+                                      }
                                     )
                             genFiles =
                                 OpenApi.Generate.files
@@ -314,315 +167,4 @@ suite =
                         Utils.sanitizeModuleName "service API (params in:body)"
                 in
                 Expect.equal moduleName (Just "ServiceApiParamsInBody")
-        , testOas "Additional Properties" additionalPropertiesOasString <|
-            \{ jsonFile, typesFile } ->
-                composeExpectations
-                    [ expectDeclarationBody "StringLists"
-                        typesFile
-                        """
-                                type alias StringLists =
-                                    Dict.Dict String (List String)
-                        """
-                    , expectDeclarationBody "decodeStringLists"
-                        jsonFile
-                        """
-                                decodeStringLists : Json.Decode.Decoder AdditionalProperties.Types.StringLists
-                                decodeStringLists =
-                                    Json.Decode.dict (Json.Decode.list Json.Decode.string)
-                        """
-                    , expectDeclarationBody "encodeStringLists"
-                        jsonFile
-                        """
-                                encodeStringLists : AdditionalProperties.Types.StringLists -> Json.Encode.Value
-                                encodeStringLists =
-                                    Json.Encode.dict Basics.identity (Json.Encode.list Json.Encode.string)
-                        """
-                    , expectDeclarationBody "VagueExtras"
-                        typesFile
-                        """
-                                type alias VagueExtras =
-                                    { additionalProperties : Dict.Dict String Json.Encode.Value
-                                    , a : Maybe String
-                                    , b : String
-                                    }
-                        """
-                    , expectDeclarationBody "encodeVagueExtras"
-                        jsonFile
-                        """
-encodeVagueExtras : AdditionalProperties.Types.VagueExtras -> Json.Encode.Value
-encodeVagueExtras rec =
-    Json.Encode.object
-        (List.append
-            (List.filterMap
-                Basics.identity
-                [ Maybe.map
-                    (\\mapUnpack -> ( "a", Json.Encode.string mapUnpack ))
-                    rec.a
-                , Just ( "b", Json.Encode.string rec.b )
-                ]
-            )
-            (List.map
-                (\\( key, value ) -> ( key, Basics.identity value ))
-                (Dict.toList rec.additionalProperties)
-            )
-        )
-                        """
-                    , expectDeclarationBody "Taxonomy"
-                        typesFile
-                        """
-                                type alias Taxonomy =
-                                    { tags :
-                                        { additionalProperties :
-                                            Dict.Dict String { isPopular : Maybe Bool, name : String }
-                                        , declaredProperty : String
-                                        }
-                                    }
-                        """
-                    , expectDeclarationBody "decodeTaxonomy" jsonFile expectedDecodeTaxonomy
-                    , expectDeclarationBody "encodeTaxonomy" jsonFile expectedEncodeTaxonomy
-                    ]
         ]
-
-
-additionalPropertiesOasString : String
-additionalPropertiesOasString =
-    """
-{
-  "openapi": "3.0.1",
-  "info": {
-    "title": "Additional Properties",
-    "version": "1"
-  },
-  "components": {
-    "schemas": {
-      "Taxonomy": {
-        "type": "object",
-        "required": [
-          "tags"
-        ],
-        "properties": {
-          "tags": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "isPopular": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "properties": {
-              "declaredProperty": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "declaredProperty"
-            ]
-          }
-        }
-      },
-      "StringLists": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "VagueExtras": {
-        "type": "object",
-        "required": ["b"],
-        "additionalProperties": true,
-        "properties": {
-          "a": {
-            "type": "string"
-          },
-          "b": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  }
-}"""
-
-
-expectedDecodeTaxonomy : String
-expectedDecodeTaxonomy =
-    """
-decodeTaxonomy : Json.Decode.Decoder AdditionalProperties.Types.Taxonomy
-decodeTaxonomy =
-    Json.Decode.succeed
-        (\\tags -> { tags = tags })
-        |> OpenApi.Common.jsonDecodeAndMap
-            (Json.Decode.field
-                "tags"
-                (Json.Decode.succeed
-                    (\\declaredProperty additionalProperties ->
-                        { declaredProperty =
-                            declaredProperty
-                        , additionalProperties =
-                            additionalProperties
-                        }
-                    )
-                    |> OpenApi.Common.jsonDecodeAndMap
-                        (Json.Decode.field
-                            "declaredProperty"
-                            Json.Decode.string
-                        )
-                    |> OpenApi.Common.jsonDecodeAndMap
-                        (Json.Decode.keyValuePairs
-                            Json.Decode.value
-                            |> Json.Decode.andThen
-                                (\\keyValuePairs ->
-                                    List.filterMap
-                                        (\\( key, jsonValue ) ->
-                                            if
-                                                List.member
-                                                    key
-                                                    [ "declaredProperty"
-                                                    ]
-                                            then
-                                                Nothing
-
-                                            else
-                                                let
-                                                    additionalPropertyDecoder =
-                                                        Json.Decode.succeed
-                                                            (\\isPopular name ->
-                                                                { isPopular =
-                                                                    isPopular
-                                                                , name =
-                                                                    name
-                                                                }
-                                                            )
-                                                            |> OpenApi.Common.jsonDecodeAndMap
-                                                                (OpenApi.Common.decodeOptionalField
-                                                                    "isPopular"
-                                                                    Json.Decode.bool
-                                                                )
-                                                            |> OpenApi.Common.jsonDecodeAndMap
-                                                                (Json.Decode.field
-                                                                    "name"
-                                                                    Json.Decode.string
-                                                                )
-                                                in
-                                                case
-                                                    Json.Decode.decodeValue
-                                                        additionalPropertyDecoder
-                                                        jsonValue
-                                                of
-                                                    Ok decodedValue ->
-                                                        Just
-                                                            (Result.Ok
-                                                                ( key
-                                                                , decodedValue
-                                                                )
-                                                            )
-
-                                                    Err decodeError ->
-                                                        Just
-                                                            (Result.Err
-                                                                ("Field '"
-                                                                    ++ key
-                                                                    ++ "': "
-                                                                    ++ Json.Decode.errorToString
-                                                                        decodeError
-                                                                )
-                                                            )
-                                        )
-                                        keyValuePairs
-                                        |> (\\resultPairs ->
-                                                let
-                                                    fieldErrors =
-                                                        List.filterMap
-                                                            (\\field ->
-                                                                case field of
-                                                                    Ok _ ->
-                                                                        Nothing
-
-                                                                    Err error ->
-                                                                        Just
-                                                                            error
-                                                            )
-                                                            resultPairs
-                                                in
-                                                if
-                                                    List.isEmpty
-                                                        fieldErrors
-                                                then
-                                                    resultPairs
-                                                        |> List.filterMap
-                                                            Result.toMaybe
-                                                        |> Dict.fromList
-                                                        |> Json.Decode.succeed
-
-                                                else
-                                                    [ \"\"\"Errors while decoding additionalProperties:
-- \"\"\"
-                                                    , String.join
-                                                        \"\"\"
-
-- \"\"\"
-                                                        fieldErrors
-                                                    , \"\"\"
-\"\"\"
-                                                    ]
-                                                        |> String.concat
-                                                        |> Json.Decode.fail
-                                           )
-                                )
-                        )
-                )
-            )
-                                """
-
-
-expectedEncodeTaxonomy : String
-expectedEncodeTaxonomy =
-    """
-encodeTaxonomy : AdditionalProperties.Types.Taxonomy -> Json.Encode.Value
-encodeTaxonomy rec =
-    Json.Encode.object
-        [ ( "tags"
-          , Json.Encode.object
-                (List.append
-                    [ ( "declaredProperty"
-                      , Json.Encode.string rec.tags.declaredProperty
-                      )
-                    ]
-                    (List.map
-                        (\\( key, value ) ->
-                            ( key
-                            , Json.Encode.object
-                                (List.filterMap
-                                    Basics.identity
-                                    [ Maybe.map
-                                        (\\mapUnpack ->
-                                            ( "isPopular"
-                                            , Json.Encode.bool mapUnpack
-                                            )
-                                        )
-                                        value.isPopular
-                                    , Just
-                                        ( "name"
-                                        , Json.Encode.string value.name
-                                        )
-                                    ]
-                                )
-                            )
-                        )
-                        (Dict.toList rec.tags.additionalProperties)
-                    )
-                )
-          )
-        ]
-"""


### PR DESCRIPTION
@wolfadex cc @miniBill 

I've removed the "snapshot" testing stuff because it doesn't gibe with the PR-comment-diff workflow. I have kept the other test file helper refactors. Let me know if you want me to revert those or do any squashing.

One caveat: `additionalProperties` is only noticed if `type: object` is alongside it. (I haven't looked into how to make the code "infer" `type: object` in this case if it's missing.)