### PR TITLE
Fix: Operation security should override top-level

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,9 @@ jobs:
       - name: Diff the outputs
         run: |
           echo '```diff' > diff.md
-          diff -w -d -r main/generated branch/generated | dd bs=1024 count=30 >> diff.md || true # We ignore diff exiting with a 1 on diff
+          diff --ignore-all-space --minimal --new-file --recursive \
+            main/generated \
+            branch/generated | dd bs=1024 count=30 >> diff.md || true # We ignore diff exiting with a 1
           echo -e '\n```' >> diff.md
 
       - name: Post a comment with the diff

--- a/elm.json
+++ b/elm.json
@@ -21,7 +21,7 @@
             "myrho/yaml": "1.0.0",
             "turboMaCk/non-empty-list-alias": "1.4.0",
             "wolfadex/elm-ansi": "3.0.0",
-            "wolfadex/elm-open-api": "1.2.0"
+            "wolfadex/elm-open-api": "2.0.0"
         },
         "indirect": {
             "Chadtech/elm-bool-extra": "2.4.2",

--- a/example/overriding-global-security-override.yaml
+++ b/example/overriding-global-security-override.yaml
@@ -1,0 +1,8 @@
+paths:
+  "/api/unprotected":
+    post:
+      # Make sure override files can override global security, per-operation.
+      security: []
+    patch:
+      # Make sure override files can override operation-level security as well.
+      security: []

--- a/example/overriding-global-security.yaml
+++ b/example/overriding-global-security.yaml
@@ -16,20 +16,40 @@ security:
   - Token: []
 paths:
   "/api/protected":
-    summary: Endpoint requiring token
-    description: Description of protected endpoint
     get:
+      summary: Endpoint requiring token
+      description: Get secret data. Auth required!
       operationId: GetProtectedData
       responses:
         200:
           $ref: "#/components/schemas/Data"
 
   "/api/unprotected":
-    summary: Unprotected (public) endpoint
-    description: "Description of unprotected endpoint"
     get:
-      security: []
+      summary: Unprotected endpoint to get data
+      description: Get some data. No auth required.
       operationId: GetUnprotectedData
+      security: []
+      responses:
+        200:
+          $ref: "#/components/schemas/Data"
+    post:
+      summary: Unprotected endpoint to store data
+      # Whoops! Security should be overridden here like for GET. Let's fix it
+      # with an override file; see ./overriding-global-security-override.yaml.
+      description: Store some data. No auth required.
+      operationId: PostUnprotectedData
+      responses:
+        200:
+          $ref: "#/components/schemas/Data"
+    patch:
+      summary: Unprotected endpoint to store data (again)
+      # Whoops! This is supposed to be unprotected, like GET. Let's fix it
+      # with an override file; see ./overriding-global-security-override.yaml.
+      security:
+        - Token: []
+      description: Store some data. No auth required.
+      operationId: PatchUnprotectedData
       responses:
         200:
           $ref: "#/components/schemas/Data"

--- a/example/overriding-global-security.yaml
+++ b/example/overriding-global-security.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.1
+info:
+  title: "Overriding global security"
+  version: 1.0.0
+components:
+  schemas:
+    Data:
+      description: "Data"
+      type: string
+  securitySchemes:
+    Token:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - Token: []
+paths:
+  "/api/protected":
+    summary: Endpoint requiring token
+    description: Description of protected endpoint
+    get:
+      operationId: GetProtectedData
+      responses:
+        200:
+          $ref: "#/components/schemas/Data"
+
+  "/api/unprotected":
+    summary: Unprotected (public) endpoint
+    description: "Description of unprotected endpoint"
+    get:
+      security: []
+      operationId: GetUnprotectedData
+      responses:
+        200:
+          $ref: "#/components/schemas/Data"

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -653,6 +653,9 @@ overrideWith override original =
                             if overrideValue == Json.Value.NullValue then
                                 res
 
+                            else if key == "security" then
+                                Result.map (\acc -> ( key, overrideValue ) :: acc) res
+
                             else
                                 Result.map2
                                     (\acc newValue -> ( key, newValue ) :: acc)

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -1494,7 +1494,9 @@ operationToAuthorizationInfo : OpenApi.Operation.Operation -> CliMonad Authoriza
 operationToAuthorizationInfo operation =
     CliMonad.andThen2
         (\globalSecurity components ->
-            (OpenApi.Operation.security operation ++ globalSecurity)
+            -- If present, the operation's security overrides globalSecurity.
+            OpenApi.Operation.security operation
+                |> Maybe.withDefault globalSecurity
                 |> List.concatMap
                     (Dict.toList << OpenApi.SecurityRequirement.requirements)
                 |> CliMonad.foldl

--- a/src/TestGenScript.elm
+++ b/src/TestGenScript.elm
@@ -20,6 +20,10 @@ run =
         recursiveAllofRefs =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/recursive-allof-refs.yaml")
 
+        overridingGlobalSecurity : OpenApi.Config.Input
+        overridingGlobalSecurity =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/overriding-global-security.yaml")
+
         singleEnum : OpenApi.Config.Input
         singleEnum =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/single-enum.yaml")
@@ -70,6 +74,7 @@ run =
             OpenApi.Config.init "./generated"
                 |> OpenApi.Config.withAutoConvertSwagger True
                 |> OpenApi.Config.withInput recursiveAllofRefs
+                |> OpenApi.Config.withInput overridingGlobalSecurity
                 |> OpenApi.Config.withInput singleEnum
                 |> OpenApi.Config.withInput patreon
                 |> OpenApi.Config.withInput realworldConduit

--- a/src/TestGenScript.elm
+++ b/src/TestGenScript.elm
@@ -23,6 +23,7 @@ run =
         overridingGlobalSecurity : OpenApi.Config.Input
         overridingGlobalSecurity =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/overriding-global-security.yaml")
+                |> OpenApi.Config.withOverrides [ OpenApi.Config.File "./example/overriding-global-security-override.yaml" ]
 
         singleEnum : OpenApi.Config.Input
         singleEnum =


### PR DESCRIPTION
**Requires** https://github.com/wolfadex/elm-open-api/pull/11 (**CI currently fails due to this**)

In order to allow schema override files to also override (replace) individual operations' `security` values, we must special-case the `JsonValue` merging logic on `key == "security"`. This is needed because otherwise `security: []` in an override will just be merged into, e.g., `security: [{ Token: [] }]` in the schema's operation, not changing anything.

This also affects how top-level `security` is handled; that may sound weird, but I think it's good/necessary, because it gives the most flexibility to override files. But it is a special case, whereas all other override data are merged with the OAS data.

@wolfadex @miniBill What do you think?