### PR TITLE
Add warning for missing enums

### DIFF
--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -127,6 +127,7 @@ files { namespace, generateTodos, effectTypes, server, formats } apiSpec =
                             ]
                             |> CliMonad.map List.concat
                     )
+                |> CliMonad.withPath (Common.UnsafeName (String.join "." namespace))
                 |> CliMonad.run
                     SchemaUtils.oneOfDeclarations
                     { openApi = apiSpec


### PR DESCRIPTION
If an enum is used but not named this will now generate a warning.

We still use the enum when validating a response, but not having it named means we can't provide type safety and we can't "validate" it when building a request.