### PR TITLE
Work around small bug

### DIFF
--- a/cli/src/Cli.elm
+++ b/cli/src/Cli.elm
@@ -876,7 +876,7 @@ decodeMaybeYaml oasPath input =
                         Ok jsonFromYaml
 
     else
-        case Yaml.Decode.fromString yamlToJsonValueDecoder input of
+        case Yaml.Decode.fromString yamlToJsonValueDecoder (input++"\n") of
             Err yamlError ->
                 -- If it errored out, it might be valid JSON that the yaml parser can't handle
                 case Json.Decode.decodeString Json.Value.decoder input of
@@ -898,6 +898,7 @@ decodeMaybeYaml oasPath input =
 
                     Ok decoded ->
                         Ok decoded
+
 
             Ok jsonFromYaml ->
                 Ok jsonFromYaml


### PR DESCRIPTION
There is a bug in the parser where if a yaml file ends with a multiline string without a final newline, it fails to parse.

This is a temporary workaround.
