### PR TITLE
Support path-level parameters in code generation

### DIFF
--- a/cli/example/path-level-params.yaml
+++ b/cli/example/path-level-params.yaml
@@ -1,0 +1,41 @@
+openapi: "3.1.0"
+info:
+  title: "Path Level Params Test"
+  version: "1.0.0"
+paths:
+  /orgs/{orgId}/teams/{teamId}/items:
+    parameters:
+      - $ref: '#/components/parameters/orgIdParam'
+      - in: path
+        name: teamId
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getItems
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                required:
+                  - count
+components:
+  parameters:
+    orgIdParam:
+      in: path
+      name: orgId
+      required: true
+      schema:
+        type: string

--- a/cli/src/TestGenScript.elm
+++ b/cli/src/TestGenScript.elm
@@ -77,6 +77,10 @@ run =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/overriding-global-security.yaml")
                 |> OpenApi.Config.withOverrides [ OpenApi.Config.File "./example/overriding-global-security-override.yaml" ]
 
+        pathLevelParams : OpenApi.Config.Input
+        pathLevelParams =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/path-level-params.yaml")
+
         patreon : OpenApi.Config.Input
         patreon =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/patreon.json")
@@ -143,6 +147,7 @@ run =
                 |> OpenApi.Config.withInput multipartFormData
                 |> OpenApi.Config.withInput nullableEnum
                 |> OpenApi.Config.withInput overridingGlobalSecurity
+                |> OpenApi.Config.withInput pathLevelParams
                 |> OpenApi.Config.withInput realworldConduit
                 |> OpenApi.Config.withInput recursiveAllOfRefs
                 |> OpenApi.Config.withInput simpleRef

--- a/src/OpenApi/Generate.elm
+++ b/src/OpenApi/Generate.elm
@@ -281,6 +281,42 @@ stripTrailingSlash input =
         input
 
 
+{-| Merge path-level parameters with operation-level parameters.
+Per the OpenAPI spec, operation-level parameters override path-level
+parameters with the same name and location.
+-}
+mergeParams :
+    List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter)
+    -> List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter)
+    -> CliMonad (List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter))
+mergeParams pathParams operationParams =
+    let
+        paramKey : OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter -> CliMonad String
+        paramKey param =
+            toConcreteParam param
+                |> CliMonad.map (\concrete -> OpenApi.Parameter.in_ concrete ++ ":" ++ OpenApi.Parameter.name concrete)
+    in
+    CliMonad.combineMap paramKey operationParams
+        |> CliMonad.map FastSet.fromList
+        |> CliMonad.andThen
+            (\operationParamKeys ->
+                pathParams
+                    |> CliMonad.combineMap
+                        (\param ->
+                            paramKey param
+                                |> CliMonad.map
+                                    (\key ->
+                                        if FastSet.member key operationParamKeys then
+                                            Nothing
+
+                                        else
+                                            Just param
+                                    )
+                        )
+                    |> CliMonad.map (\filtered -> List.filterMap identity filtered ++ operationParams)
+            )
+
+
 pathDeclarations : List OpenApi.Config.EffectType -> ServerInfo -> CliMonad (List CliMonad.Declaration)
 pathDeclarations effectTypes server =
     CliMonad.getApiSpec
@@ -302,7 +338,7 @@ pathDeclarations effectTypes server =
                                 |> List.filterMap (\( method, getter ) -> Maybe.map (Tuple.pair method) (getter path))
                                 |> CliMonad.combineMap
                                     (\( method, operation ) ->
-                                        toRequestFunctions server effectTypes method url operation
+                                        toRequestFunctions server effectTypes method url (OpenApi.Path.parameters path) operation
                                             |> CliMonad.errorToWarning
                                     )
                                 |> CliMonad.map (List.filterMap identity >> List.concat)
@@ -489,8 +525,17 @@ requestBodyToDeclarations name reference =
                 |> CliMonad.withPath name
 
 
-toRequestFunctions : ServerInfo -> List OpenApi.Config.EffectType -> String -> String -> OpenApi.Operation.Operation -> CliMonad (List CliMonad.Declaration)
-toRequestFunctions server effectTypes method pathUrl operation =
+toRequestFunctions : ServerInfo -> List OpenApi.Config.EffectType -> String -> String -> List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter) -> OpenApi.Operation.Operation -> CliMonad (List CliMonad.Declaration)
+toRequestFunctions server effectTypes method pathUrl pathLevelParams operation =
+    mergeParams pathLevelParams (OpenApi.Operation.parameters operation)
+        |> CliMonad.andThen
+            (\allParams ->
+                toRequestFunctionsHelp server effectTypes method pathUrl operation allParams
+            )
+
+
+toRequestFunctionsHelp : ServerInfo -> List OpenApi.Config.EffectType -> String -> String -> OpenApi.Operation.Operation -> List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter) -> CliMonad (List CliMonad.Declaration)
+toRequestFunctionsHelp server effectTypes method pathUrl operation allParams =
     let
         step : OperationUtils -> CliMonad (List CliMonad.Declaration)
         step ({ successType, bodyTypeAnnotation, errorTypeDeclaration, errorTypeAnnotation } as operationUtils) =
@@ -524,7 +569,7 @@ toRequestFunctions server effectTypes method pathUrl operation =
                             |> CliMonad.andThen
                                 (\params ->
                                     toConfigParamAnnotation
-                                        { operation = operation
+                                        { allParams = allParams
                                         , successAnnotation = successAnnotation
                                         , errorBodyAnnotation = bodyTypeAnnotation
                                         , errorTypeAnnotation = errorTypeAnnotation
@@ -534,11 +579,11 @@ toRequestFunctions server effectTypes method pathUrl operation =
                                         }
                                 )
                         )
-                        (replacedUrl server auth pathUrl operation)
+                        (replacedUrl server auth pathUrl allParams)
                 )
                 (operationToContentSchema operation)
                 (operationToAuthorizationInfo operation)
-                (operationToHeaderParams operation)
+                (operationToHeaderParams allParams)
                 (case successType of
                     SuccessType t ->
                         SchemaUtils.typeToAnnotationWithNullable t
@@ -1324,10 +1369,9 @@ operationToGroup operation =
             "Operations"
 
 
-operationToHeaderParams : OpenApi.Operation.Operation -> CliMonad (List (Elm.Expression -> ( Elm.Expression, Elm.Expression, Bool )))
-operationToHeaderParams operation =
-    operation
-        |> OpenApi.Operation.parameters
+operationToHeaderParams : List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter) -> CliMonad (List (Elm.Expression -> ( Elm.Expression, Elm.Expression, Bool )))
+operationToHeaderParams params =
+    params
         |> CliMonad.combineMap
             (\param ->
                 toConcreteParam param
@@ -1373,8 +1417,8 @@ operationToHeaderParams operation =
         |> CliMonad.map (List.filterMap identity)
 
 
-replacedUrl : ServerInfo -> AuthorizationInfo -> String -> OpenApi.Operation.Operation -> CliMonad (Elm.Expression -> Elm.Expression)
-replacedUrl server authInfo pathUrl operation =
+replacedUrl : ServerInfo -> AuthorizationInfo -> String -> List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter) -> CliMonad (Elm.Expression -> Elm.Expression)
+replacedUrl server authInfo pathUrl params =
     let
         pathSegments : List String
         pathSegments =
@@ -1452,8 +1496,7 @@ replacedUrl server authInfo pathUrl operation =
                     MultipleServers _ ->
                         Gen.Url.Builder.call_.crossOrigin (Elm.get "server" config) (Elm.list replacedSegments) allQueryParams
     in
-    operation
-        |> OpenApi.Operation.parameters
+    params
         |> CliMonad.combineMap
             (\param ->
                 toConcreteParam param
@@ -1969,7 +2012,7 @@ multipartContent mediaType =
 
 
 toConfigParamAnnotation :
-    { operation : OpenApi.Operation.Operation
+    { allParams : List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter)
     , successAnnotation : Elm.Annotation.Annotation
     , errorBodyAnnotation : Elm.Annotation.Annotation
     , errorTypeAnnotation : Elm.Annotation.Annotation
@@ -2029,7 +2072,7 @@ toConfigParamAnnotation options =
                 , lamderaProgramTest = toMsgLamderaProgramTest
                 }
         )
-        (operationToUrlParams options.operation)
+        (operationToUrlParams options.allParams)
 
 
 type ServerInfo
@@ -2095,13 +2138,8 @@ serverInfo server =
                 |> CliMonad.succeed
 
 
-operationToUrlParams : OpenApi.Operation.Operation -> CliMonad (List ( Common.UnsafeName, Elm.Annotation.Annotation ))
-operationToUrlParams operation =
-    let
-        params : List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter)
-        params =
-            OpenApi.Operation.parameters operation
-    in
+operationToUrlParams : List (OpenApi.Reference.ReferenceOr OpenApi.Parameter.Parameter) -> CliMonad (List ( Common.UnsafeName, Elm.Annotation.Annotation ))
+operationToUrlParams params =
     if List.isEmpty params then
         CliMonad.succeed []
 

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -1,4 +1,4 @@
-module Test.OpenApi.Generate exposing (fuzzInputName, fuzzTitle, issue48, noEnumSort, pr267, uuidArrayParam)
+module Test.OpenApi.Generate exposing (fuzzInputName, fuzzTitle, issue48, noEnumSort, pathLevelParams, pr267, uuidArrayParam)
 
 import Ansi.Color
 import CliMonad
@@ -718,6 +718,173 @@ noEnumSort =
 
                         ( _, Err e ) ->
                             Expect.fail ("Error generating sorted: " ++ Debug.toString e)
+
+
+pathLevelParams : Test
+pathLevelParams =
+    Test.test "Path-level parameters are merged into operations" <|
+        \() ->
+            let
+                oasString : String
+                oasString =
+                    String.Multiline.here """
+                        openapi: "3.1.0"
+                        info:
+                          title: "Path Level Params Test"
+                          version: "1.0.0"
+                        paths:
+                          /orgs/{orgId}/teams/{teamId}/items:
+                            parameters:
+                              - $ref: '#/components/parameters/orgIdParam'
+                              - in: path
+                                name: teamId
+                                required: true
+                                schema:
+                                  type: string
+                            get:
+                              operationId: getItems
+                              parameters:
+                                - in: query
+                                  name: status
+                                  required: false
+                                  schema:
+                                    type: string
+                              responses:
+                                "200":
+                                  description: OK
+                                  content:
+                                    application/json:
+                                      schema:
+                                        type: object
+                                        properties:
+                                          count:
+                                            type: integer
+                                        required:
+                                          - count
+                        components:
+                          parameters:
+                            orgIdParam:
+                              in: path
+                              name: orgId
+                              required: true
+                              schema:
+                                type: string
+                    """
+            in
+            case
+                oasString
+                    |> Yaml.Decode.fromString yamlToJsonValueDecoder
+                    |> Result.mapError Debug.toString
+                    |> Result.andThen
+                        (\json ->
+                            json
+                                |> Json.Decode.decodeValue OpenApi.decode
+                                |> Result.mapError Debug.toString
+                        )
+            of
+                Err e ->
+                    Expect.fail e
+
+                Ok oas ->
+                    let
+                        genFiles :
+                            Result
+                                CliMonad.Message
+                                { modules :
+                                    List
+                                        { moduleName : List String
+                                        , declarations : FastDict.Dict String { group : String, declaration : Elm.Declaration }
+                                        }
+                                , warnings : List CliMonad.Message
+                                , requiredPackages : FastSet.Set String
+                                }
+                        genFiles =
+                            OpenApi.Generate.files
+                                { namespace = [ "Output" ]
+                                , generateTodos = False
+                                , effectTypes = [ OpenApi.Config.ElmHttpCmd ]
+                                , server = OpenApi.Config.Default
+                                , formats = OpenApi.Config.defaultFormats
+                                , warnOnMissingEnums = True
+                                , keepGoing = False
+                                }
+                                oas
+                    in
+                    case genFiles of
+                        Err e ->
+                            Expect.fail ("Error in generation: " ++ Debug.toString e)
+
+                        Ok { modules } ->
+                            case modules of
+                                [ apiFile ] ->
+                                    let
+                                        apiFileString : String
+                                        apiFileString =
+                                            String.Multiline.here """
+                                                module Output.Api exposing ( getItems )
+
+                                                {-|
+                                                @docs getItems
+                                                -}
+
+
+                                                import Dict
+                                                import Http
+                                                import Json.Decode
+                                                import OpenApi.Common
+                                                import Url.Builder
+
+
+                                                {- ## Operations -}
+
+
+                                                getItems :
+                                                    { toMsg : Result (OpenApi.Common.Error e String) { count : Int } -> msg
+                                                    , params : { orgId : String, teamId : String, status : Maybe String }
+                                                    }
+                                                    -> Cmd msg
+                                                getItems config =
+                                                    Http.request
+                                                        { url =
+                                                            Url.Builder.absolute
+                                                                [ "orgs"
+                                                                , config.params.orgId
+                                                                , "teams"
+                                                                , config.params.teamId
+                                                                , "items"
+                                                                ]
+                                                                (List.filterMap
+                                                                     Basics.identity
+                                                                     [ Maybe.map
+                                                                         (Url.Builder.string "status")
+                                                                         config.params.status
+                                                                     ]
+                                                                )
+                                                        , method = "GET"
+                                                        , headers = []
+                                                        , expect =
+                                                            OpenApi.Common.expectJsonCustom
+                                                                (Dict.fromList [])
+                                                                (Json.Decode.succeed (\\count -> { count = count })
+                                                                     |> OpenApi.Common.jsonDecodeAndMap
+                                                                            (Json.Decode.field "count" Json.Decode.int)
+                                                                )
+                                                                config.toMsg
+                                                        , body = Http.emptyBody
+                                                        , timeout = Nothing
+                                                        , tracker = Nothing
+                                                        }
+                                            """
+                                    in
+                                    expectEqualMultiline apiFileString (fileToString apiFile)
+
+                                _ ->
+                                    Expect.fail
+                                        ("Expected to generate 1 file but found "
+                                            ++ (List.length modules |> String.fromInt)
+                                            ++ ": "
+                                            ++ moduleNames modules
+                                        )
 
 
 yamlToJsonValueDecoder : Yaml.Decode.Decoder Json.Encode.Value

--- a/tests/Test/OpenApi/Generate.elm
+++ b/tests/Test/OpenApi/Generate.elm
@@ -807,6 +807,7 @@ pathLevelParams =
                                 , formats = OpenApi.Config.defaultFormats
                                 , warnOnMissingEnums = True
                                 , keepGoing = False
+                                , noEnumSort = False
                                 }
                                 oas
                     in


### PR DESCRIPTION
Merge path item parameters with operation parameters per the OpenAPI spec. Previously, parameters defined at the path level (shared across all operations) were silently ignored, causing path params to appear as literal strings in generated URLs.