### PR TITLE
Sort TestGenScript.elm input definitions alphabetically

### DIFF
--- a/cli/src/TestGenScript.elm
+++ b/cli/src/TestGenScript.elm
@@ -39,9 +39,22 @@ run =
         binaryResponse =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/binary-response.yaml")
 
+        bug : Int -> OpenApi.Config.Input
+        bug n =
+            OpenApi.Config.inputFrom (OpenApi.Config.File ("./example/openapi-generator-bugs/" ++ String.fromInt n ++ ".yaml"))
+
         cookieAuth : OpenApi.Config.Input
         cookieAuth =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/cookie-auth.yaml")
+
+        dbFahrplanApi : OpenApi.Config.Input
+        dbFahrplanApi =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/db-fahrplan-api-specification.yaml")
+
+        gitHub : OpenApi.Config.Input
+        gitHub =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/github-spec.json")
+                |> OpenApi.Config.withWarnOnMissingEnums False
 
         ifconfigOvh : OpenApi.Config.Input
         ifconfigOvh =
@@ -64,6 +77,10 @@ run =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/overriding-global-security.yaml")
                 |> OpenApi.Config.withOverrides [ OpenApi.Config.File "./example/overriding-global-security-override.yaml" ]
 
+        patreon : OpenApi.Config.Input
+        patreon =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/patreon.json")
+
         realworldConduit : OpenApi.Config.Input
         realworldConduit =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/realworld-conduit.yaml")
@@ -80,9 +97,9 @@ run =
         singleEnum =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/single-enum.yaml")
 
-        uuidArrayParam : OpenApi.Config.Input
-        uuidArrayParam =
-            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/uuid-array-param.yaml")
+        telegramBot : OpenApi.Config.Input
+        telegramBot =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/telegram-bot.json")
 
         trustmark : OpenApi.Config.Input
         trustmark =
@@ -102,30 +119,13 @@ run =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/tuple-triple.yaml")
                 |> OpenApi.Config.withEffectTypes [ OpenApi.Config.ElmHttpCmd ]
 
+        uuidArrayParam : OpenApi.Config.Input
+        uuidArrayParam =
+            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/uuid-array-param.yaml")
+
         viaggiatreno : OpenApi.Config.Input
         viaggiatreno =
             OpenApi.Config.inputFrom (OpenApi.Config.File "./example/viaggiatreno.yaml")
-
-        bug : Int -> OpenApi.Config.Input
-        bug n =
-            OpenApi.Config.inputFrom (OpenApi.Config.File ("./example/openapi-generator-bugs/" ++ String.fromInt n ++ ".yaml"))
-
-        dbFahrplanApi : OpenApi.Config.Input
-        dbFahrplanApi =
-            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/db-fahrplan-api-specification.yaml")
-
-        gitHub : OpenApi.Config.Input
-        gitHub =
-            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/github-spec.json")
-                |> OpenApi.Config.withWarnOnMissingEnums False
-
-        patreon : OpenApi.Config.Input
-        patreon =
-            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/patreon.json")
-
-        telegramBot : OpenApi.Config.Input
-        telegramBot =
-            OpenApi.Config.inputFrom (OpenApi.Config.File "./example/telegram-bot.json")
 
         profileConfig : OpenApi.Config.Config
         profileConfig =


### PR DESCRIPTION
The input definitions were split into two alphabetically-sorted groups. This moves `bug`, `dbFahrplanApi`, `gitHub`, `patreon`, and `telegramBot` from the second group into their correct alphabetical positions in the first group for consistency.