### PR TITLE
Workaround Main Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "dev": "cd cli && elm-pages run src/Cli.elm",
         "docs": "elm make --docs=docs.json",
-        "build": "cd cli && elm-pages bundle-script src/Cli.elm --output ../dist/elm-open-api.js --debug",
+        "build": "cd cli && elm-pages bundle-script src/Cli.elm --output ../dist/elm-open-api.js --optimize 1",
         "review": "elm-review",
         "review:watch": "elm-review --watch --fix",
         "format": "elm-format src tests --validate",


### PR DESCRIPTION
This PR implements a workaround around an upstream issue https://github.com/mdgriffith/elm-optimize-level-2/pull/120 by disabling `--optimize 2`, and falling back to `--optimize 1`.

---

Additionally, I add a [`npm prepare`](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts) script which relies on `npm` (for cross-compatibility) and makes it easier for people to install this package via `git` (and my project has it as such:

```json
"devDependencies": {
  "elm-open-api": "github:harmont-dev/elm-open-api-cli#25d7..."
}
```

**Note**: This adds a `package-lock.json`.

If you find the `package-lock.json` undesirable, I can revert the addition of the `npm prepare` script.

---

**Heads up**: PR made with the help of LLMs